### PR TITLE
Changed values in @Mod annotation of forge template to rely on variables

### DIFF
--- a/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
+++ b/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
@@ -45,7 +45,11 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.*;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
+import com.intellij.psi.PsiManager;
 import org.apache.commons.io.FileUtils;
 import org.gradle.tooling.BuildLauncher;
 import org.gradle.tooling.GradleConnector;
@@ -73,7 +77,16 @@ import org.jetbrains.plugins.groovy.lang.psi.impl.GroovyPsiElementFactoryImpl;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.java
+++ b/src/main/java/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.java
@@ -16,7 +16,15 @@ import com.intellij.ui.awt.RelativePoint;
 import com.intellij.util.ui.UIUtil;
 import org.apache.commons.lang.WordUtils;
 
-import javax.swing.*;
+import javax.swing.JTextField;
+import javax.swing.JPanel;
+import javax.swing.JLabel;
+import javax.swing.JComboBox;
+import javax.swing.JProgressBar;
+import javax.swing.JCheckBox;
+import javax.swing.SwingWorker;
+import javax.swing.JComponent;
+
 import java.awt.event.ActionListener;
 import java.util.List;
 

--- a/src/main/java/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.java
+++ b/src/main/java/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.java
@@ -7,7 +7,6 @@ import com.demonwav.mcdev.platform.forge.versionapi.ForgeVersion;
 import com.demonwav.mcdev.platform.forge.versionapi.McpVersion;
 import com.demonwav.mcdev.platform.forge.versionapi.McpVersionEntry;
 import com.demonwav.mcdev.platform.hybrid.SpongeForgeProjectConfiguration;
-
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.ui.popup.Balloon;
@@ -17,17 +16,9 @@ import com.intellij.ui.awt.RelativePoint;
 import com.intellij.util.ui.UIUtil;
 import org.apache.commons.lang.WordUtils;
 
+import javax.swing.*;
 import java.awt.event.ActionListener;
 import java.util.List;
-
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JProgressBar;
-import javax.swing.JTextField;
-import javax.swing.SwingWorker;
 
 public class ForgeProjectSettingsWizard extends MinecraftModuleWizardStep {
 
@@ -138,8 +129,8 @@ public class ForgeProjectSettingsWizard extends MinecraftModuleWizardStep {
             pluginVersionField.setEditable(false);
         }
 
-        mainClassField.setText(this.creator.getGroupId() + '.' + this.creator.getArtifactId()
-                + '.' + WordUtils.capitalizeFully(this.creator.getArtifactId()));
+        mainClassField.setText(this.creator.getGroupId().toLowerCase() + '.' + this.creator.getArtifactId().toLowerCase()
+                + '.' + WordUtils.capitalize(this.creator.getArtifactId()));
 
         if (creator.getSettings().size() > 1) {
             mainClassField.setText(mainClassField.getText() + creator.getSettings().get(creator.index).type.getNormalName());

--- a/src/main/resources/fileTemplates/j2ee/forge_main_class.java.ft
+++ b/src/main/resources/fileTemplates/j2ee/forge_main_class.java.ft
@@ -13,7 +13,7 @@ public class ${CLASS_NAME} {
 
     public static final String MOD_ID = "${ARTIFACT_ID}";
     public static final String MOD_NAME = "${PLUGIN_NAME}";
-    public static final String VERSION = "${PLUGIN_VERSION";
+    public static final String VERSION = "${PLUGIN_VERSION}";
 
     @EventHandler
     public void init(FMLInitializationEvent event) {

--- a/src/main/resources/fileTemplates/j2ee/forge_main_class.java.ft
+++ b/src/main/resources/fileTemplates/j2ee/forge_main_class.java.ft
@@ -5,11 +5,15 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 
 @Mod(
-        modid = "${ARTIFACT_ID}",
-        name = "${PLUGIN_NAME}",
-        version = "${PLUGIN_VERSION}"
+        modid = ${CLASS_NAME}.MOD_ID,
+        name = ${CLASS_NAME}.MOD_NAME,
+        version = ${CLASS_NAME}.VERSION
 )
 public class ${CLASS_NAME} {
+
+    public static final String MOD_ID = "${ARTIFACT_ID}";
+    public static final String MOD_NAME = "${PLUGIN_NAME}";
+    public static final String VERSION = "${PLUGIN_VERSION";
 
     @EventHandler
     public void init(FMLInitializationEvent event) {


### PR DESCRIPTION
It is customary for Forge developers to define the Mod ID, the name, and the version of their mod in constants defined in the main class. This is so that they can change all references to them globally, and they don't need to constantly look for the old values when, say, updating the version of the mod.