### PR TITLE
Add code folding for Mixin injection targets

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/folding/MixinFoldingBuilder.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/folding/MixinFoldingBuilder.kt
@@ -1,0 +1,124 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.folding
+
+import com.demonwav.mcdev.platform.mixin.MixinModuleType
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
+import com.demonwav.mcdev.platform.mixin.util.MixinMemberReference
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.CustomFoldingBuilder
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.CommonClassNames
+import com.intellij.psi.JavaRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationMemberValue
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiSubstitutor
+import com.intellij.psi.PsiTypeCastExpression
+import com.intellij.psi.PsiVariable
+import com.intellij.psi.impl.source.tree.ChildRole
+import com.intellij.psi.impl.source.tree.CompositeElement
+import com.intellij.psi.util.PsiFormatUtil
+import com.intellij.psi.util.PsiFormatUtilBase
+import com.intellij.psi.util.PsiFormatUtilBase.SHOW_CONTAINING_CLASS
+
+class MixinFoldingBuilder : CustomFoldingBuilder() {
+
+    // I'm not dumb
+    override fun isDumbAware() = false
+
+    override fun isRegionCollapsedByDefault(node: ASTNode): Boolean {
+        val settings = MixinFoldingSettings.instance.state
+        return when (node.psi) {
+            is PsiTypeCastExpression -> settings.foldObjectCasts
+            is PsiAnnotationMemberValue -> settings.foldTargetDescriptors
+            else -> true
+        }
+    }
+
+    override fun getLanguagePlaceholderText(node: ASTNode, range: TextRange): String {
+        val element = node.psi
+        when (element) {
+            is PsiTypeCastExpression -> {
+                val castText = element.castType?.text ?: return node.text
+                return "($castText)"
+            }
+            is PsiAnnotationMemberValue -> {
+                val value = element.constantStringValue ?: return node.text
+                val member = MixinMemberReference.parse(value)?.resolveMember(element.project, element.resolveScope) ?: return node.text
+                return when (member) {
+                    is PsiMethod -> PsiFormatUtil.formatMethod(member, PsiSubstitutor.EMPTY,
+                        PsiFormatUtilBase.SHOW_NAME or PsiFormatUtilBase.SHOW_PARAMETERS or SHOW_CONTAINING_CLASS,
+                        PsiFormatUtilBase.SHOW_TYPE)
+                    is PsiVariable -> PsiFormatUtil.formatVariable(member, PsiFormatUtilBase.SHOW_NAME or SHOW_CONTAINING_CLASS, PsiSubstitutor.EMPTY)
+                    else -> member.presentation?.presentableText ?: node.text
+                }
+            }
+        }
+
+        return node.text
+    }
+
+    override fun buildLanguageFoldRegions(descriptors: MutableList<FoldingDescriptor>, root: PsiElement, document: Document, quick: Boolean) {
+        if (root !is PsiJavaFile || !MixinModuleType.isInModule(root)) {
+            return
+        }
+
+        root.accept(Visitor(descriptors))
+    }
+
+    private class Visitor(private val descriptors: MutableList<FoldingDescriptor>) : JavaRecursiveElementWalkingVisitor() {
+
+        val settings = MixinFoldingSettings.instance.state
+
+        override fun visitAnnotation(annotation: PsiAnnotation) {
+            super.visitAnnotation(annotation)
+
+            if (!settings.foldTargetDescriptors) {
+                return
+            }
+
+            val qualifiedName = annotation.qualifiedName ?: return
+            if (qualifiedName != AT) {
+                return
+            }
+
+            val target = annotation.findDeclaredAttributeValue("target") ?: return
+            descriptors.add(FoldingDescriptor(target, target.textRange))
+        }
+
+        override fun visitTypeCastExpression(expression: PsiTypeCastExpression) {
+            super.visitTypeCastExpression(expression)
+
+            if (!settings.foldObjectCasts) {
+                return
+            }
+
+            val innerCast = expression.operand as? PsiTypeCastExpression ?: return
+            if ((innerCast.type as? PsiClassType)?.resolve()?.qualifiedName == CommonClassNames.JAVA_LANG_OBJECT) {
+                // Fold the two casts
+
+                val start = (expression as? CompositeElement)?.findChildByRole(ChildRole.LPARENTH) ?: return
+                val end = (innerCast as? CompositeElement)?.findChildByRole(ChildRole.RPARENTH) ?: return
+
+                descriptors.add(FoldingDescriptor(expression, TextRange(start.startOffset, end.startOffset + end.textLength)))
+            }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/folding/MixinFoldingOptionsProvider.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/folding/MixinFoldingOptionsProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.folding
+
+import com.intellij.application.options.editor.CodeFoldingOptionsProvider
+import com.intellij.openapi.options.BeanConfigurable
+
+class MixinFoldingOptionsProvider
+    : BeanConfigurable<MixinFoldingSettings.State>(MixinFoldingSettings.instance.state), CodeFoldingOptionsProvider {
+
+    init {
+        val settings = MixinFoldingSettings.instance
+        checkBox("Mixin: Target descriptors", { settings.state.foldTargetDescriptors }, { b -> settings.state.foldTargetDescriptors = b })
+        checkBox("Mixin: Object casts", { settings.state.foldObjectCasts }, { b -> settings.state.foldObjectCasts = b })
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/folding/MixinFoldingSettings.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/folding/MixinFoldingSettings.kt
@@ -1,0 +1,39 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.folding
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+@State(name = "MixinFoldingSettings", storages = arrayOf(Storage("editor.codeinsight.xml")))
+class MixinFoldingSettings : PersistentStateComponent<MixinFoldingSettings.State> {
+
+    data class State(
+        var foldTargetDescriptors: Boolean = true,
+        var foldObjectCasts: Boolean = false
+    )
+
+    private var state = State()
+
+    override fun getState(): State = this.state
+
+    override fun loadState(state: State) {
+        this.state = state
+    }
+
+    companion object {
+        val instance: MixinFoldingSettings
+            get() = ServiceManager.getService(MixinFoldingSettings::class.java)
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -176,6 +176,11 @@
         <!--region MIXIN-->
         <!---->
 
+        <!-- Folding -->
+        <applicationService serviceImplementation="com.demonwav.mcdev.platform.mixin.folding.MixinFoldingSettings" />
+        <codeFoldingOptionsProvider instance="com.demonwav.mcdev.platform.mixin.folding.MixinFoldingOptionsProvider" />
+        <lang.foldingBuilder language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.folding.MixinFoldingBuilder"/>
+
         <implicitUsageProvider implementation="com.demonwav.mcdev.platform.mixin.insight.MixinImplicitUsageProvider"/>
         <deadCode implementation="com.demonwav.mcdev.platform.mixin.insight.MixinEntryPoint"/>
 


### PR DESCRIPTION
Adds some code folding for Mixin classes. Right now there is an option to fold target descriptors and the (in my opinion) annoying `(Object)` casts that are necessary sometimes.

Both options can be toggled in the Code folding options. As we discussed a while ago, I've made the folding of target descriptors enabled by default and disabled the folding of object casts.

<details> 
  <summary>Screenshot of target descriptor folding</summary>

![screenshot_20170614_170201](https://user-images.githubusercontent.com/3035868/27139427-4a111168-5123-11e7-9774-904ff1f5d532.png)


</details>

<details> 
  <summary>Screenshot of Object cast folding</summary>

![screenshot_20170614_170341](https://user-images.githubusercontent.com/3035868/27139484-6eb6e4a2-5123-11e7-9eac-3b4bed921229.png)

</details>

<p><br>The original code will appear when clicking on the folded code, just like when IntelliJ IDEA collapses method bodies etc.</p>