### PR TITLE
Fix Forge project generation for MC1.12+ and enhance Minecraft version selection

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.kt
@@ -201,6 +201,7 @@ class ForgeProjectSettingsWizard(private val creator: MinecraftProjectCreator) :
         if (fullVersion != null) {
             settings!!.forgeVersion = fullVersion
         }
+        settings!!.mcVersion = minecraftVersionBox.selectedItem as String
     }
 
     fun error() {

--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeProjectConfiguration.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeProjectConfiguration.kt
@@ -27,6 +27,7 @@ open class ForgeProjectConfiguration : ProjectConfiguration() {
 
     var mcpVersion: String = ""
     var forgeVersion: String = ""
+    var mcVersion: String = ""
 
     init {
         type = PlatformType.FORGE

--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeTemplate.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeTemplate.kt
@@ -13,11 +13,13 @@ package com.demonwav.mcdev.platform.forge
 import com.demonwav.mcdev.platform.BaseTemplate
 import com.demonwav.mcdev.platform.hybrid.SpongeForgeProjectConfiguration
 import com.demonwav.mcdev.util.MinecraftFileTemplateGroupFactory
+import com.demonwav.mcdev.util.SemanticVersion
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import java.util.Properties
 
 object ForgeTemplate {
+    private val MC_1_12 = SemanticVersion("1.12")
 
     fun applyBuildGradleTemplate(project: Project,
                                  file: VirtualFile,
@@ -31,6 +33,13 @@ object ForgeTemplate {
 
         if (configuration is SpongeForgeProjectConfiguration) {
             properties.setProperty("SPONGE_FORGE", "true")
+        }
+        // Fixes builds for MC1.12+, requires FG 2.3
+        val mcVersion = SemanticVersion(configuration.mcVersion)
+        if (mcVersion >= MC_1_12) {
+            properties.setProperty("FORGEGRADLE_VERSION", "2.3")
+        } else {
+            properties.setProperty("FORGEGRADLE_VERSION", "2.2")
         }
 
         BaseTemplate.applyTemplate(project, file, MinecraftFileTemplateGroupFactory.FORGE_BUILD_GRADLE_TEMPLATE, properties)

--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeTemplate.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeTemplate.kt
@@ -19,7 +19,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import java.util.Properties
 
 object ForgeTemplate {
-    private val MC_1_12 = SemanticVersion("1.12")
+    private val MC_1_12 = SemanticVersion.parse("1.12")
 
     fun applyBuildGradleTemplate(project: Project,
                                  file: VirtualFile,
@@ -35,7 +35,7 @@ object ForgeTemplate {
             properties.setProperty("SPONGE_FORGE", "true")
         }
         // Fixes builds for MC1.12+, requires FG 2.3
-        val mcVersion = SemanticVersion(configuration.mcVersion)
+        val mcVersion = SemanticVersion.parse(configuration.mcVersion)
         if (mcVersion >= MC_1_12) {
             properties.setProperty("FORGEGRADLE_VERSION", "2.3")
         } else {

--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
@@ -11,6 +11,7 @@
 package com.demonwav.mcdev.platform.forge.version
 
 import com.demonwav.mcdev.util.gson
+import com.demonwav.mcdev.util.SemanticVersion
 import com.demonwav.mcdev.util.sortVersions
 import java.io.IOException
 import java.net.URL
@@ -23,16 +24,16 @@ class ForgeVersion private constructor(private val map: Map<*, *>) {
     }
 
     fun getRecommended(versions: List<String>): String {
-        var recommended = "1.7"
+        var recommended = SemanticVersion("1.7")
         for (version in versions) {
             getPromo(version) ?: continue
-
-            if (recommended < version) {
-                recommended = version
+            val semantic = SemanticVersion(version)
+            if (recommended < semantic) {
+                recommended = semantic
             }
         }
 
-        return recommended
+        return recommended.value
     }
 
     fun getPromo(version: String): Double? {

--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
@@ -24,16 +24,16 @@ class ForgeVersion private constructor(private val map: Map<*, *>) {
     }
 
     fun getRecommended(versions: List<String>): String {
-        var recommended = SemanticVersion("1.7")
+        var recommended = SemanticVersion.parse("1.7")
         for (version in versions) {
             getPromo(version) ?: continue
-            val semantic = SemanticVersion(version)
+            val semantic = SemanticVersion.parse(version)
             if (recommended < semantic) {
                 recommended = semantic
             }
         }
 
-        return recommended.value
+        return recommended.toString()
     }
 
     fun getPromo(version: String): Double? {

--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
@@ -33,7 +33,7 @@ class ForgeVersion private constructor(private val map: Map<*, *>) {
             }
         }
 
-        return recommended.toString()
+        return recommended.versionString
     }
 
     fun getPromo(version: String): Double? {

--- a/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
@@ -13,18 +13,18 @@ package com.demonwav.mcdev.util
 import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.PreReleasePart
 import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.ReleasePart
 
-class SemanticVersion(val value: String) : Comparable<SemanticVersion> {
-    val parts = value.split(".").map {
-        if (it.contains("_pre")) {
-            val subParts = it.split("_pre")
-            PreReleasePart(subParts[0].toInt(), subParts[1].toInt())
-        } else {
-            ReleasePart(it.toInt())
-        }
-    }
-
+/**
+ * Represents a comparable and generalised "semantic version".
+ * Each constituent part (delimited by periods in a version string) contributes
+ * to the version ranking with decreasing priority from left to right.
+ */
+class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion> {
     override fun compareTo(other: SemanticVersion): Int {
-        val result = parts.zip(other.parts).fold(0, { acc, (a, b) -> if (acc == -1) acc else a.compareTo(b) })
+        // Zipping limits the compared parts to the shorter version, then we perform a component-wise comparison
+        // Short-circuits if any component of this version is smaller/older
+        val result = parts.zip(other.parts).fold(0) { acc, (a, b) -> if (acc == -1) acc else a.compareTo(b) }
+        // When all the parts are equal, the longer version wins
+        // Generally speaking, 1.0 is considered older than 1.0.1 (see MC 1.12 vs 1.12.1)
         if (parts.size != other.parts.size && result == 0) {
             return parts.size - other.parts.size
         }
@@ -37,11 +37,39 @@ class SemanticVersion(val value: String) : Comparable<SemanticVersion> {
             else -> false
         }
 
-    override fun hashCode(): Int {
-        return parts.hashCode()
-    }
+    override fun hashCode() = parts.hashCode()
+
+    override fun toString() = parts.map { it.toString() }.joinToString(".")
 
     companion object {
+        /**
+         * Parses a version string into a comparable representation.
+         * @throws IllegalArgumentException if any part of the version string cannot be parsed as integer or split into pre-release parts.
+         */
+        fun parse(value: String): SemanticVersion {
+            fun parseInt(part: String): Int =
+                if (part.all { it.isDigit() })
+                    part.toInt()
+                else
+                    throw IllegalArgumentException("Failed to parse version part as integer: $part")
+
+            val parts = value.split('.').map {
+                if (it.contains("_pre")) {
+                    // There have been cases of Forge builds for MC pre-releases (1.7.10_pre4)
+                    // We're consuming the 10_pre4 and extracting 10 and 4 from it
+                    val subParts = it.split("_pre")
+                    if (subParts.size == 2) {
+                        PreReleasePart(parseInt(subParts[0]), parseInt(subParts[1]))
+                    } else {
+                        throw IllegalArgumentException("Failed to split pre-release version part into two numbers: $it")
+                    }
+                } else {
+                    ReleasePart(parseInt(it))
+                }
+            }
+            return SemanticVersion(parts)
+        }
+
         sealed class VersionPart : Comparable<VersionPart> {
             data class ReleasePart(val version: Int) : VersionPart() {
                 override fun compareTo(other: VersionPart) =
@@ -49,6 +77,8 @@ class SemanticVersion(val value: String) : Comparable<SemanticVersion> {
                         is PreReleasePart -> if (version != other.version) version - other.version else 1
                         is ReleasePart -> version - other.version
                     }
+
+                override fun toString() = version.toString()
             }
 
             data class PreReleasePart(val version: Int, val pre: Int) : VersionPart() {
@@ -57,6 +87,8 @@ class SemanticVersion(val value: String) : Comparable<SemanticVersion> {
                         is PreReleasePart -> if (version != other.version) version - other.version else pre - other.pre
                         is ReleasePart -> if (version != other.version) version - other.version else -1
                     }
+
+                override fun toString() = "${version}_pre$pre"
             }
         }
     }

--- a/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
@@ -19,6 +19,8 @@ import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.ReleasePart
  * to the version ranking with decreasing priority from left to right.
  */
 class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion> {
+    val versionString = parts.map { it.versionString }.joinToString(".");
+
     override fun compareTo(other: SemanticVersion): Int {
         // Zipping limits the compared parts to the shorter version, then we perform a component-wise comparison
         // Short-circuits if any component of this version is smaller/older
@@ -38,8 +40,6 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
         }
 
     override fun hashCode() = parts.hashCode()
-
-    override fun toString() = parts.map { it.toString() }.joinToString(".")
 
     companion object {
         /**
@@ -71,24 +71,26 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
         }
 
         sealed class VersionPart : Comparable<VersionPart> {
+            abstract val versionString: String
+
             data class ReleasePart(val version: Int) : VersionPart() {
+                override val versionString = version.toString()
+
                 override fun compareTo(other: VersionPart) =
                     when (other) {
                         is PreReleasePart -> if (version != other.version) version - other.version else 1
                         is ReleasePart -> version - other.version
                     }
-
-                override fun toString() = version.toString()
             }
 
             data class PreReleasePart(val version: Int, val pre: Int) : VersionPart() {
+                override val versionString = "${version}_pre$pre"
+
                 override fun compareTo(other: VersionPart) =
                     when (other) {
                         is PreReleasePart -> if (version != other.version) version - other.version else pre - other.pre
                         is ReleasePart -> if (version != other.version) version - other.version else -1
                     }
-
-                override fun toString() = "${version}_pre$pre"
             }
         }
     }

--- a/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
@@ -1,0 +1,63 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util
+
+import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.PreReleasePart
+import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.ReleasePart
+
+class SemanticVersion(val value: String) : Comparable<SemanticVersion> {
+    val parts = value.split(".").map {
+        if (it.contains("_pre")) {
+            val subParts = it.split("_pre")
+            PreReleasePart(subParts[0].toInt(), subParts[1].toInt())
+        } else {
+            ReleasePart(it.toInt())
+        }
+    }
+
+    override fun compareTo(other: SemanticVersion): Int {
+        val result = parts.zip(other.parts).fold(0, { acc, (a, b) -> if (acc == -1) acc else a.compareTo(b) })
+        if (parts.size != other.parts.size && result == 0) {
+            return parts.size - other.parts.size
+        }
+        return result
+    }
+
+    override fun equals(other: Any?) =
+        when (other) {
+            is SemanticVersion -> parts.size == other.parts.size && parts.zip(other.parts).all { (a, b) -> a == b }
+            else -> false
+        }
+
+    override fun hashCode(): Int {
+        return parts.hashCode()
+    }
+
+    companion object {
+        sealed class VersionPart : Comparable<VersionPart> {
+            data class ReleasePart(val version: Int) : VersionPart() {
+                override fun compareTo(other: VersionPart) =
+                    when (other) {
+                        is PreReleasePart -> if (version != other.version) version - other.version else 1
+                        is ReleasePart -> version - other.version
+                    }
+            }
+
+            data class PreReleasePart(val version: Int, val pre: Int) : VersionPart() {
+                override fun compareTo(other: VersionPart) =
+                    when (other) {
+                        is PreReleasePart -> if (version != other.version) version - other.version else pre - other.pre
+                        is ReleasePart -> if (version != other.version) version - other.version else -1
+                    }
+            }
+        }
+    }
+}

--- a/src/main/resources/fileTemplates/j2ee/forge_build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/forge_build.gradle.ft
@@ -12,7 +12,7 @@ buildscript {
 #end
     }
     dependencies {
-        classpath "net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT"
+        classpath "net.minecraftforge.gradle:ForgeGradle:${FORGEGRADLE_VERSION}-SNAPSHOT"
 #if (${SPONGE_FORGE})
         classpath "gradle.plugin.org.spongepowered:spongegradle:0.8.1"
 #end


### PR DESCRIPTION
As of version 1.12 of Minecraft, Forge projects are required to use ForgeGradle 2.3, while earlier versions should still use FG 2.2. This was not accounted for in the plugin, but this PR fixes the issue by making the ForgeGradle version variable based on the Minecraft version. Since I implemented a `SemanticVersion` utility for this which allows us to compare Minecraft (and Forge, technically) versions easily, I also "fixed" the way the initial Minecraft version is retrieved in the wizard, namely by properly comparing the versions, assuming semantic versioning. The previous method of just comparing version strings was (currently) always yielding "1.9.4", since the String comparison compares each character individually and favours those that come later in the charset. This did not respect the components of the semantic versions. 1.9.4 was alwyas selected because the '9' was always the biggest character at that position, so we wouldn't get another result until Minecraft 1.90 is released :D.