### PR TITLE
Touchup Canary Platform

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryFileIconProvider.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryFileIconProvider.kt
@@ -31,7 +31,7 @@ class CanaryFileIconProvider : FileIconProvider {
         val module = ModuleUtilCore.findModuleForFile(file, project) ?: return null
         val canaryModule = MinecraftFacet.getInstance(module, CanaryModuleType, NeptuneModuleType) ?: return null
 
-        if (file == canaryModule.getCanaryInf() || file == canaryModule.getNeptuneInf()) {
+        if (file == canaryModule.canaryInf || file == canaryModule.neptuneInf) {
             return canaryModule.icon
         }
         return null

--- a/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryFileIconProvider.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryFileIconProvider.kt
@@ -31,7 +31,7 @@ class CanaryFileIconProvider : FileIconProvider {
         val module = ModuleUtilCore.findModuleForFile(file, project) ?: return null
         val canaryModule = MinecraftFacet.getInstance(module, CanaryModuleType, NeptuneModuleType) ?: return null
 
-        if (file == canaryModule.getCanaryInf()) {
+        if (file == canaryModule.getCanaryInf() || file == canaryModule.getNeptuneInf()) {
             return canaryModule.icon
         }
         return null

--- a/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryModule.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryModule.kt
@@ -32,6 +32,7 @@ class CanaryModule<out T : AbstractModuleType<*>>(facet: MinecraftFacet, overrid
 
     override val type: PlatformType = moduleType.platformType
     private var canaryInf: VirtualFile? = null
+    private var neptuneInf: VirtualFile? = null
 
     init {
         setup()
@@ -39,6 +40,7 @@ class CanaryModule<out T : AbstractModuleType<*>>(facet: MinecraftFacet, overrid
 
     private fun setup() {
         canaryInf = facet.findFile(CanaryConstants.CANARY_INF, SourceType.RESOURCE)
+        neptuneInf = facet.findFile(CanaryConstants.NEPTUNE_INF, SourceType.RESOURCE)
     }
 
     fun getCanaryInf(): VirtualFile? {
@@ -48,6 +50,15 @@ class CanaryModule<out T : AbstractModuleType<*>>(facet: MinecraftFacet, overrid
             setup()
         }
         return canaryInf
+    }
+
+    fun getNeptuneInf(): VirtualFile? {
+        if (neptuneInf == null) {
+            // try and find the file again if it's not already present
+            // when this object was first created it may not have been ready
+            setup()
+        }
+        return neptuneInf
     }
 
     override fun isEventClassValid(eventClass: PsiClass, method: PsiMethod?) =
@@ -89,6 +100,7 @@ class CanaryModule<out T : AbstractModuleType<*>>(facet: MinecraftFacet, overrid
         super.dispose()
 
         canaryInf = null
+        neptuneInf = null
     }
 
     companion object {
@@ -102,7 +114,7 @@ class CanaryModule<out T : AbstractModuleType<*>>(facet: MinecraftFacet, overrid
             val list = newMethod.parameterList
             val parameter = JavaPsiFacade.getElementFactory(project)
                 .createParameter(
-                    "event",
+                    "hook",
                     PsiClassType.getTypeByName(chosenClass.qualifiedName, project, GlobalSearchScope.allScope(project))
                 )
             list.add(parameter)

--- a/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryModule.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryModule.kt
@@ -31,35 +31,22 @@ import com.intellij.psi.search.GlobalSearchScope
 class CanaryModule<out T : AbstractModuleType<*>>(facet: MinecraftFacet, override val moduleType: T) : AbstractModule(facet) {
 
     override val type: PlatformType = moduleType.platformType
-    private var canaryInf: VirtualFile? = null
-    private var neptuneInf: VirtualFile? = null
-
-    init {
-        setup()
-    }
-
-    private fun setup() {
-        canaryInf = facet.findFile(CanaryConstants.CANARY_INF, SourceType.RESOURCE)
-        neptuneInf = facet.findFile(CanaryConstants.NEPTUNE_INF, SourceType.RESOURCE)
-    }
-
-    fun getCanaryInf(): VirtualFile? {
-        if (canaryInf == null) {
-            // try and find the file again if it's not already present
-            // when this object was first created it may not have been ready
-            setup()
+    var canaryInf: VirtualFile? = null
+        get() {
+            if (field == null) {
+                field = facet.findFile(CanaryConstants.CANARY_INF, SourceType.RESOURCE)
+            }
+            return field
         }
-        return canaryInf
-    }
-
-    fun getNeptuneInf(): VirtualFile? {
-        if (neptuneInf == null) {
-            // try and find the file again if it's not already present
-            // when this object was first created it may not have been ready
-            setup()
+        private set
+    var neptuneInf: VirtualFile? = null
+        get() {
+            if (field == null) {
+                field = facet.findFile(CanaryConstants.NEPTUNE_INF, SourceType.RESOURCE)
+            }
+            return field
         }
-        return neptuneInf
-    }
+        private set
 
     override fun isEventClassValid(eventClass: PsiClass, method: PsiMethod?) =
         CanaryConstants.HOOK_CLASS == eventClass.qualifiedName

--- a/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryModuleType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/canary/CanaryModuleType.kt
@@ -34,6 +34,7 @@ object CanaryModuleType : AbstractModuleType<CanaryModule<CanaryModuleType>>("ne
 
     init {
         CommonColors.applyStandardColors(colorMap, CanaryConstants.CHAT_FORMAT_CLASS)
+        CommonColors.applyStandardColors(colorMap, CanaryConstants.MCP_CHAT_FORMATTING)
         CanaryLegacyColors.applyLegacyColors(colorMap, CanaryConstants.LEGACY_COLORS_CLASS)
         CanaryLegacyColors.applyLegacyColors(colorMap, CanaryConstants.LEGACY_TEXT_FORMAT_CLASS)
     }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/canary/NeptuneModuleType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/canary/NeptuneModuleType.kt
@@ -26,6 +26,7 @@ object NeptuneModuleType : AbstractModuleType<CanaryModule<NeptuneModuleType>>("
 
     init {
         CommonColors.applyStandardColors(colorMap, CanaryConstants.CHAT_FORMAT_CLASS)
+        CommonColors.applyStandardColors(colorMap, CanaryConstants.MCP_CHAT_FORMATTING)
         CanaryLegacyColors.applyLegacyColors(colorMap, CanaryConstants.LEGACY_COLORS_CLASS)
         CanaryLegacyColors.applyLegacyColors(colorMap, CanaryConstants.LEGACY_TEXT_FORMAT_CLASS)
     }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/canary/util/CanaryConstants.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/canary/util/CanaryConstants.kt
@@ -13,6 +13,7 @@ package com.demonwav.mcdev.platform.canary.util
 object CanaryConstants {
 
     const val CANARY_INF = "Canary.inf"
+    const val NEPTUNE_INF = "Neptune.inf"
 
     /* Hooks */
     const val HOOK_HANDLER_ANNOTATION = "net.canarymod.hook.HookHandler"


### PR DESCRIPTION
- Don't refer to hooks as 'event's in parameter names
- Add icon to Neptune.inf files (optional plugin descriptor in NeptuneMod)
- Reinstate the MCP text format colouring (although for both canary + neptune this time)