### PR TITLE
add copy AT entry menu item

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
@@ -14,8 +14,6 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.*
 import com.intellij.ui.LightColors
 import com.intellij.ui.awt.RelativePoint
-import java.awt.Toolkit.getDefaultToolkit
-import javafx.scene.input.Clipboard.getSystemClipboard
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
@@ -1,0 +1,106 @@
+package com.demonwav.mcdev.platform.mcp.actions
+
+import com.demonwav.mcdev.platform.mcp.McpModuleType
+import com.demonwav.mcdev.platform.mixin.util.findFirstShadowTarget
+import com.demonwav.mcdev.util.getDataFromActionEvent
+import com.demonwav.mcdev.util.invokeLater
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataKeys
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.ui.popup.Balloon
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.psi.*
+import com.intellij.ui.LightColors
+import com.intellij.ui.awt.RelativePoint
+import java.awt.Toolkit.getDefaultToolkit
+import javafx.scene.input.Clipboard.getSystemClipboard
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+
+
+
+class CopyATAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val data = getDataFromActionEvent(e) ?: return showBalloon("Unknown failure", e)
+
+        if (data.element !is PsiIdentifier) {
+            showBalloon("Not a valid element", e)
+            return
+        }
+
+        val mcpModule = data.instance.getModuleOfType(McpModuleType) ?: return showBalloon("No mappings found", e)
+
+        mcpModule.srgManager?.srgMap?.done { srgMap ->
+            var parent = data.element.parent
+
+            if (parent is PsiMember) {
+                val shadowTarget = parent.findFirstShadowTarget()
+                if (shadowTarget != null) {
+                    parent = shadowTarget
+                }
+            }
+
+            if (parent is PsiReference) {
+                parent = parent.resolve()
+            }
+
+            when (parent) {
+                is PsiField -> {
+                    val srg = srgMap.findSrgField(parent) ?: return@done showBalloon("No SRG name found", e)
+                    copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName + " " + srg.name + " #"+parent.name)
+                }
+                is PsiMethod -> {
+                    val srg = srgMap.findSrgMethod(parent) ?: return@done showBalloon("No SRG name found", e)
+                    copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName + " " + srg.name + srg.descriptor+ " #"+parent.name)
+                }
+                is PsiClass -> {
+                    val classMcpToSrg = srgMap.findSrgClass(parent) ?: return@done showBalloon("No SRG name found", e)
+                    copyToClipboard(data.editor, data.element, classMcpToSrg)
+                }
+                else ->
+                    showBalloon("Not a valid element", e)
+            }
+        } ?: showBalloon("No mappings found", e)
+    }
+
+    private fun showBalloon(message: String, e: AnActionEvent) {
+        val balloon = JBPopupFactory.getInstance()
+            .createHtmlTextBalloonBuilder(message, null, LightColors.YELLOW, null)
+            .setHideOnAction(true)
+            .setHideOnClickOutside(true)
+            .setHideOnKeyOutside(true)
+            .createBalloon()
+
+        val statusBar = WindowManager.getInstance().getStatusBar(DataKeys.PROJECT.getData(e.dataContext))
+
+        invokeLater { balloon.show(RelativePoint.getCenterOf(statusBar.component), Balloon.Position.atRight) }
+    }
+
+    private fun copyToClipboard(editor: Editor, element: PsiElement, text: String) {
+        val stringSelection = StringSelection(text)
+        val clpbrd = Toolkit.getDefaultToolkit().systemClipboard
+        clpbrd.setContents(stringSelection, null)
+        showSuccessBalloon(editor, element, "Copied "+text)
+    }
+
+    private fun showSuccessBalloon(editor: Editor, element: PsiElement, text: String) {
+        val balloon = JBPopupFactory.getInstance()
+            .createHtmlTextBalloonBuilder(text, null, LightColors.SLIGHTLY_GREEN, null)
+            .setHideOnAction(true)
+            .setHideOnClickOutside(true)
+            .setHideOnKeyOutside(true)
+            .createBalloon()
+
+        invokeLater {
+            balloon.show(
+                    RelativePoint(
+                            editor.contentComponent,
+                            editor.visualPositionToXY(editor.offsetToVisualPosition(element.textRange.endOffset))
+                    ),
+                    Balloon.Position.atRight
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
@@ -27,8 +27,6 @@ import com.intellij.ui.awt.RelativePoint
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 
-
-
 class CopyATAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val data = getDataFromActionEvent(e) ?: return showBalloon("Unknown failure", e)
@@ -57,18 +55,17 @@ class CopyATAction : AnAction() {
             when (parent) {
                 is PsiField -> {
                     val srg = srgMap.findSrgField(parent) ?: return@done showBalloon("No SRG name found", e)
-                    copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName + " " + srg.name + " #"+parent.name)
+                    copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName+" "+srg.name+" #"+parent.name)
                 }
                 is PsiMethod -> {
                     val srg = srgMap.findSrgMethod(parent) ?: return@done showBalloon("No SRG name found", e)
-                    copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName + " " + srg.name + srg.descriptor+ " #"+parent.name)
+                    copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName+" "+srg.name+srg.descriptor+" #"+parent.name)
                 }
                 is PsiClass -> {
                     val classMcpToSrg = srgMap.findSrgClass(parent) ?: return@done showBalloon("No SRG name found", e)
                     copyToClipboard(data.editor, data.element, classMcpToSrg)
                 }
-                else ->
-                    showBalloon("Not a valid element", e)
+                else -> showBalloon("Not a valid element", e)
             }
         } ?: showBalloon("No mappings found", e)
     }
@@ -83,7 +80,9 @@ class CopyATAction : AnAction() {
 
         val statusBar = WindowManager.getInstance().getStatusBar(DataKeys.PROJECT.getData(e.dataContext))
 
-        invokeLater { balloon.show(RelativePoint.getCenterOf(statusBar.component), Balloon.Position.atRight) }
+        invokeLater { 
+            balloon.show(RelativePoint.getCenterOf(statusBar.component), Balloon.Position.atRight) 
+        }
     }
 
     private fun copyToClipboard(editor: Editor, element: PsiElement, text: String) {
@@ -103,11 +102,11 @@ class CopyATAction : AnAction() {
 
         invokeLater {
             balloon.show(
-                    RelativePoint(
-                            editor.contentComponent,
-                            editor.visualPositionToXY(editor.offsetToVisualPosition(element.textRange.endOffset))
-                    ),
-                    Balloon.Position.atRight
+                RelativePoint(
+                        editor.contentComponent,
+                        editor.visualPositionToXY(editor.offsetToVisualPosition(element.textRange.endOffset))
+                ),
+                Balloon.Position.atRight
             )
         }
     }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyATAction.kt
@@ -1,3 +1,13 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
 package com.demonwav.mcdev.platform.mcp.actions
 
 import com.demonwav.mcdev.platform.mcp.McpModuleType

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyAtAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/actions/CopyAtAction.kt
@@ -13,29 +13,35 @@ package com.demonwav.mcdev.platform.mcp.actions
 import com.demonwav.mcdev.platform.mcp.srg.McpSrgMap
 import com.demonwav.mcdev.util.ActionData
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiField
-import com.intellij.psi.PsiMethod
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.*
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
 
-class FindSrgMappingAction : SrgActionBase() {
-
+class CopyAtAction : SrgActionBase() {
     override fun withSrgTarget(parent: PsiElement, srgMap: McpSrgMap, e: AnActionEvent, data: ActionData) {
         when (parent) {
             is PsiField -> {
                 val srg = srgMap.findSrgField(parent) ?: return showBalloon("No SRG name found", e)
-                showSuccessBalloon(data.editor, data.element, "SRG name: "+srg.name)
+                copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName+" "+srg.name+" #"+parent.name)
             }
             is PsiMethod -> {
                 val srg = srgMap.findSrgMethod(parent) ?: return showBalloon("No SRG name found", e)
-                showSuccessBalloon(data.editor, data.element, "SRG name: "+srg.name+srg.descriptor)
+                copyToClipboard(data.editor, data.element, parent.containingClass?.qualifiedName+" "+srg.name+srg.descriptor+" #"+parent.name)
             }
             is PsiClass -> {
                 val classMcpToSrg = srgMap.findSrgClass(parent) ?: return showBalloon("No SRG name found", e)
-                showSuccessBalloon(data.editor, data.element, "SRG name: "+classMcpToSrg)
+                copyToClipboard(data.editor, data.element, classMcpToSrg)
             }
             else -> showBalloon("Not a valid element", e)
         }
+    }
+
+    private fun copyToClipboard(editor: Editor, element: PsiElement, text: String) {
+        val stringSelection = StringSelection(text)
+        val clpbrd = Toolkit.getDefaultToolkit().systemClipboard
+        clpbrd.setContents(stringSelection, null)
+        showSuccessBalloon(editor, element, "Copied "+text)
     }
 
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -703,7 +703,7 @@
                 description="Find the associated SRG mapping for this element">
             <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu2"/>
         </action>
-        <action class="com.demonwav.mcdev.platform.mcp.actions.CopyATAction" id="CopyATAction"
+        <action class="com.demonwav.mcdev.platform.mcp.actions.CopyAtAction" id="CopyATAction"
                 text="Copy AT Entry to Clipboard"
                 description="Copy the reference to clipboard in Access Transformer format">
             <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu2"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -703,6 +703,11 @@
                 description="Find the associated SRG mapping for this element">
             <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu2"/>
         </action>
+        <action class="com.demonwav.mcdev.platform.mcp.actions.CopyATAction" id="CopyATAction"
+                text="Copy AT Entry to Clipboard"
+                description="Copy the reference to clipboard in Access Transformer format">
+            <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu2"/>
+        </action>
         <action class="com.demonwav.mcdev.platform.mcp.actions.GotoAtEntryAction" id="GotoAtEntry"
                 text="Go To AT Entry"
                 description="Go to the relevant Access Transformer entry, if it exists">


### PR DESCRIPTION
Basically a copy of the Get SRG Name task, which copies a (partial) AT entry to the clipboard. Only missing the access specifier.

Currently to do this I need to use the Get SRG Name action, select the text in the balloon and `ctrl-c` (and enter the rest manually of course)