### PR TITLE
Fix Forge+Sponge project generation

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.kt
@@ -202,7 +202,7 @@ class ForgeProjectSettingsWizard(private val creator: MinecraftProjectCreator) :
         if (fullVersion != null) {
             settings!!.forgeVersion = fullVersion
         }
-        settings!!.mcVersion = minecraftVersionBox.selectedItem as String
+        settings!!.mcVersion = version!!
     }
 
     fun error() {

--- a/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
@@ -12,6 +12,7 @@ package com.demonwav.mcdev.util
 
 import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.PreReleasePart
 import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.ReleasePart
+import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.TextPart
 
 /**
  * Represents a comparable and generalised "semantic version".
@@ -24,7 +25,7 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
     override fun compareTo(other: SemanticVersion): Int {
         // Zipping limits the compared parts to the shorter version, then we perform a component-wise comparison
         // Short-circuits if any component of this version is smaller/older
-        val result = parts.zip(other.parts).fold(0) { acc, (a, b) -> if (acc == -1) acc else a.compareTo(b) }
+        val result = parts.zip(other.parts).fold(0) { acc, (a, b) -> if (acc != 0) acc else a.compareTo(b) }
         // When all the parts are equal, the longer version wins
         // Generally speaking, 1.0 is considered older than 1.0.1 (see MC 1.12 vs 1.12.1)
         if (parts.size != other.parts.size && result == 0) {
@@ -42,6 +43,15 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
     override fun hashCode() = parts.hashCode()
 
     companion object {
+        /**
+         * The higher the priority value associated with a certain part, the higher it is ranked in comparisons.
+         * Unknown parts will always be "rated" lower and equal among each other.
+         */
+        val TEXT_PRIORITIES = mapOf(
+            "snapshot" to 0,
+            "rc" to 1
+        )
+
         /**
          * Parses a version string into a comparable representation.
          * @throws IllegalArgumentException if any part of the version string cannot be parsed as integer or split into pre-release parts.
@@ -63,6 +73,12 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
                     } else {
                         throw IllegalArgumentException("Failed to split pre-release version part into two numbers: $it")
                     }
+                } else if (it.contains("-")) {
+                    // We might consume snapshot versions as well
+                    // Those are generally rated the lowest in comparisons
+                    // As a simplification, treat anything separated by a dash like that
+                    val subParts = it.split("-", limit = 2)
+                    TextPart(parseInt(subParts[0]), subParts[1])
                 } else {
                     ReleasePart(parseInt(it))
                 }
@@ -78,8 +94,9 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
 
                 override fun compareTo(other: VersionPart) =
                     when (other) {
-                        is PreReleasePart -> if (version != other.version) version - other.version else 1
                         is ReleasePart -> version - other.version
+                        is PreReleasePart -> if (version != other.version) version - other.version else 1
+                        is TextPart -> if (version != other.version) version - other.version else 1
                     }
             }
 
@@ -88,8 +105,22 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
 
                 override fun compareTo(other: VersionPart) =
                     when (other) {
-                        is PreReleasePart -> if (version != other.version) version - other.version else pre - other.pre
                         is ReleasePart -> if (version != other.version) version - other.version else -1
+                        is PreReleasePart -> if (version != other.version) version - other.version else pre - other.pre
+                        is TextPart -> if (version != other.version) version - other.version else 1
+                    }
+            }
+
+            data class TextPart(val version: Int, val text: String) : VersionPart() {
+                private val priority = TEXT_PRIORITIES[text.toLowerCase()] ?: -1
+
+                override val versionString = "$version-$text"
+
+                override fun compareTo(other: VersionPart) =
+                    when (other) {
+                        is ReleasePart -> if (version != other.version) version - other.version else -1
+                        is PreReleasePart -> if (version != other.version) version - other.version else -1
+                        is TextPart -> if (version != other.version) version - other.version else priority - other.priority
                     }
             }
         }

--- a/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
@@ -22,17 +22,8 @@ import com.demonwav.mcdev.util.SemanticVersion.Companion.VersionPart.TextPart
 class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion> {
     val versionString = parts.joinToString(".") { it.versionString }
 
-    override fun compareTo(other: SemanticVersion): Int {
-        // Zipping limits the compared parts to the shorter version, then we perform a component-wise comparison
-        // Short-circuits if any component of this version is smaller/older
-        val result = parts.zip(other.parts).fold(0) { acc, (a, b) -> if (acc != 0) acc else a.compareTo(b) }
-        // When all the parts are equal, the longer version wins
-        // Generally speaking, 1.0 is considered older than 1.0.1 (see MC 1.12 vs 1.12.1)
-        if (parts.size != other.parts.size && result == 0) {
-            return parts.size - other.parts.size
-        }
-        return result
-    }
+    override fun compareTo(other: SemanticVersion): Int =
+        naturalOrder<VersionPart>().lexicographical().compare(parts, other.parts)
 
     override fun equals(other: Any?) =
         when (other) {

--- a/src/main/kotlin/com/demonwav/mcdev/util/sorting.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/sorting.kt
@@ -10,62 +10,27 @@
 
 package com.demonwav.mcdev.util
 
-import java.util.ArrayList
-import java.util.Arrays
 import java.util.Comparator
-import java.util.stream.Collectors
-import java.util.stream.Stream
 
-val LEXICOGRAPHICAL_ORDER: Comparator<IntArray> = Comparator { one, two ->
-    val length = Math.min(one.size, two.size)
-    for (i in 0 until length) {
-        val first = one[i]
-        val second = two[i]
-
-        if (first < second) {
-            return@Comparator -1
-        } else if (second < first) {
-            return@Comparator 1
+fun <T> Comparator<in T>.lexicographical(): Comparator<in Iterable<T>> =
+    Comparator { left, right ->
+        // Zipping limits the compared parts to the shorter list, then we perform a component-wise comparison
+        // Short-circuits if any component of the left side is smaller or greater
+        left.zip(right).fold(0) { acc, (a, b) -> if (acc != 0) return@Comparator acc else this.compare(a, b) }.let {
+            // When all the parts are equal, the longer list wins (is greater)
+            if (it == 0) {
+                left.count() - right.count()
+            } else {
+                // Still required if the last part was not equal, the short-circuiting does not cover that
+                it
+            }
         }
     }
-
-    // We've got here so they are now equal, if one has more then they are not equal
-    if (one.size < two.size) {
-        return@Comparator -1
-    } else if (two.size < one.size) {
-        return@Comparator 1
-    }
-    // They are the same
-    return@Comparator 0
-}
-
-val REVERSE_LEXICOGRAPHICAL_ORDER: Comparator<IntArray> = LEXICOGRAPHICAL_ORDER.reversed()
 
 /**
  * This is the lowest version value we will let users choose, to make our lives easier.
  */
-private val ARRAY_1_8_8 = intArrayOf(1, 8, 8)
+private val MC_1_8_8 = SemanticVersion.parse("1.8.8")
 
-fun sortVersions(versions: Collection<*>): List<String> {
-    // Populate a list of the keys (and cast them to String) so they can be sorted
-    val list = ArrayList<String>(versions.size)
-    list.addAll(versions.stream().map(Any?::toString).collect(Collectors.toList<String>()))
-
-    // We map each version string (1.2, 1.9.4, 1.10, etc) to an array of integers {1, 2}, {1, 9, 4}, {1, 10} so we
-    // can lexicographically order them. We throw out the odd-balls in the process (like 1.10-pre4)
-    val intList = list.stream().distinct().mapNotNull { s ->
-        try {
-            return@mapNotNull Stream.of(*s.split("\\.".toRegex()).dropLastWhile(String::isEmpty).toTypedArray())
-                .mapToInt { Integer.parseInt(it) }.toArray()
-        } catch (e: NumberFormatException) {
-            return@mapNotNull null
-        }
-    }.collect(Collectors.toCollection { ArrayList<IntArray>() })
-
-    // Sort them correctly
-    intList.sortWith(REVERSE_LEXICOGRAPHICAL_ORDER)
-    intList.removeIf { ints -> LEXICOGRAPHICAL_ORDER.compare(ints, ARRAY_1_8_8) < 0 }
-
-    return intList.stream().map{ ints -> Arrays.stream(ints).mapToObj(Int::toString).collect(Collectors.joining(".")) }
-        .collect(Collectors.toList<String>())
-}
+fun sortVersions(versions: Collection<*>): List<String> =
+    versions.map(Any?::toString).map(SemanticVersion.Companion::parse).sortedDescending().filter { it >= MC_1_8_8 }.map { it.toString() }

--- a/src/main/kotlin/com/demonwav/mcdev/util/utils.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/utils.kt
@@ -146,3 +146,13 @@ val gson = Gson()
 inline fun <reified T : Any> Gson.fromJson(text: String): T = fromJson(text, object : TypeToken<T>() {}.type)
 
 fun <K> Map<K, *>.containsAllKeys(vararg keys: K) = keys.all { this.containsKey(it) }
+
+/**
+ * Splits a string into the longest prefix matching a predicate and the corresponding suffix *not* matching.
+ *
+ * Note: Name inspired by Scala.
+ */
+inline fun String.span(predicate: (Char) -> Boolean): Pair<String, String> {
+    val prefix = takeWhile(predicate)
+    return prefix to drop(prefix.length)
+}


### PR DESCRIPTION
This fixes #331. In addition to addressing that issue, this also introduces a more generic lexicographical sorting method as well as a replacement for the very Java-esque MC version sorting function. Furthermore, `SemanticVersion` now is capable of handling snapshots properly. I've added a very simple priority system that can be easily expanded in the future.