### PR TITLE
Fix Comparable contract for SemanticVersion parts

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeTemplate.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeTemplate.kt
@@ -19,7 +19,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import java.util.Properties
 
 object ForgeTemplate {
-    val MC_1_12 = SemanticVersion.parse("1.12")
+    val MC_1_12 = SemanticVersion.release(1, 12)
 
     fun applyBuildGradleTemplate(project: Project,
                                  file: VirtualFile,

--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/version/ForgeVersion.kt
@@ -24,7 +24,7 @@ class ForgeVersion private constructor(private val map: Map<*, *>) {
     }
 
     fun getRecommended(versions: List<String>): String {
-        var recommended = SemanticVersion.parse("1.7")
+        var recommended = SemanticVersion.release(1, 7)
         for (version in versions) {
             getPromo(version) ?: continue
             val semantic = SemanticVersion.parse(version)

--- a/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/SemanticVersion.kt
@@ -50,6 +50,11 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
         val SEPARATORS = listOf('-', '_')
 
         /**
+         * Creates a simple release version where each provided value forms a part (read from left to right).
+         */
+        fun release(vararg parts: Int) = SemanticVersion(parts.map(::ReleasePart))
+
+        /**
          * Parses a version string into a comparable representation.
          * @throws IllegalArgumentException if any part of the version string cannot be parsed as integer or split into text parts.
          */
@@ -112,6 +117,17 @@ class SemanticVersion(val parts: List<VersionPart>) : Comparable<SemanticVersion
                                 else -> number - other.number
                             }
                     }
+
+                override fun hashCode(): Int {
+                    return version + 31 * text.hashCode() + 31 * number
+                }
+
+                override fun equals(other: Any?): Boolean {
+                    return when (other) {
+                        is TextPart -> other.version == version && other.text == text && other.number == number
+                        else -> false
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/com/demonwav/mcdev/util/sorting.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/sorting.kt
@@ -30,7 +30,7 @@ fun <T> Comparator<in T>.lexicographical(): Comparator<in Iterable<T>> =
 /**
  * This is the lowest version value we will let users choose, to make our lives easier.
  */
-private val MC_1_8_8 = SemanticVersion.parse("1.8.8")
+private val MC_1_8_8 = SemanticVersion.release(1, 8, 8)
 
 fun sortVersions(versions: Collection<*>): List<String> =
     versions.map(Any?::toString).map(SemanticVersion.Companion::parse).sortedDescending().filter { it >= MC_1_8_8 }.map { it.toString() }


### PR DESCRIPTION
While modifying the textual parts of semantic versions to be more generic, I accidentally broke the contract for `Comparable<T>` (namely that a comparison should yield zero iff two objects are equal). While this shouldn't have been a problem in practice (most versions wouldn't have text parts anyways).

Additionally, I added a simple, release-only factory method in order to prevent constant versions having to go through the parsing. If it's desirable, I'd also add all version constants to a central `MCVersions` object in order to prevent unnecessary duplication (and to keep them correct).