### PR TITLE
Auto-complete keys in localizations from default

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/i18n/lang/I18nCompletionContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/i18n/lang/I18nCompletionContributor.kt
@@ -16,6 +16,7 @@ import com.demonwav.mcdev.i18n.Scope
 import com.demonwav.mcdev.i18n.findDefaultLangEntries
 import com.demonwav.mcdev.i18n.lang.gen.psi.I18nEntry
 import com.demonwav.mcdev.i18n.lang.gen.psi.I18nTypes
+import com.demonwav.mcdev.util.getSimilarity
 import com.demonwav.mcdev.util.mcDomain
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionParameters
@@ -83,31 +84,10 @@ class I18nCompletionContributor : CompletionContributor() {
             prefixResult.addElement(
                 PrioritizedLookupElement.withPriority(
                     LookupElementBuilder.create(key).withIcon(PlatformAssets.MINECRAFT_ICON),
-                    1.0 + key.getValue(text)
+                    1.0 + key.getSimilarity(text)
                 )
             )
         }
-    }
-
-    private fun String.getValue(text: String): Int {
-        if (this == text) {
-            return 1_000_000 // exact match
-        }
-
-        val lowerCaseThis = this.toLowerCase()
-        val lowerCaseText = text.toLowerCase()
-
-        if (lowerCaseThis == lowerCaseText) {
-            return 100_000 // lowercase exact match
-        }
-
-        val distance = Math.min(lowerCaseThis.length, lowerCaseText.length)
-        for (i in 0 until distance) {
-            if (lowerCaseThis[i] != lowerCaseText[i]) {
-                return i
-            }
-        }
-        return distance
     }
 
     companion object {

--- a/src/main/kotlin/com/demonwav/mcdev/i18n/lang/I18nCompletionContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/i18n/lang/I18nCompletionContributor.kt
@@ -1,0 +1,118 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.i18n.lang
+
+import com.demonwav.mcdev.asset.PlatformAssets
+import com.demonwav.mcdev.i18n.I18nConstants
+import com.demonwav.mcdev.i18n.Scope
+import com.demonwav.mcdev.i18n.findDefaultLangEntries
+import com.demonwav.mcdev.i18n.lang.gen.psi.I18nEntry
+import com.demonwav.mcdev.i18n.lang.gen.psi.I18nTypes
+import com.demonwav.mcdev.util.mcDomain
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.CompletionUtil
+import com.intellij.codeInsight.completion.PrioritizedLookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.patterns.PlatformPatterns.elementType
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiUtilCore
+
+class I18nCompletionContributor : CompletionContributor() {
+    override fun invokeAutoPopup(position: PsiElement, typeChar: Char): Boolean {
+        if (typeChar == '.') {
+            return true
+        }
+        return super.invokeAutoPopup(position, typeChar)
+    }
+
+    override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+        if (parameters.completionType != CompletionType.BASIC) {
+            return
+        }
+
+        val position = parameters.position
+        if (!PsiUtilCore.findLanguageFromElement(position).isKindOf(I18nLanguage)) {
+            return
+        }
+
+        val file = position.containingFile.originalFile.virtualFile
+        if (file.nameWithoutExtension == I18nConstants.DEFAULT_LOCALE) {
+            return
+        }
+
+        if (KEY_PATTERN.accepts(position) || DUMMY_PATTERN.accepts(position)) {
+            val text = position.text.let { it.substring(0, it.length - CompletionUtil.DUMMY_IDENTIFIER.length) }
+            val domain = file.mcDomain
+            handleKey(text, position, domain, result)
+        }
+    }
+
+    private fun handleKey(text: String, element: PsiElement, domain: String?, result: CompletionResultSet) {
+        if (text.isEmpty()) {
+            return
+        }
+
+        val defaultEntries = element.project.findDefaultLangEntries(scope = Scope.GLOBAL, domain = domain)
+        val existingKeys = element.containingFile.children.mapNotNull { (it as? I18nEntry)?.key }
+        val prefixResult = result.withPrefixMatcher(text)
+
+        var counter = 0
+        for (entry in defaultEntries) {
+            val key = entry.key
+
+            if (!key.contains(text) || existingKeys.contains(key)) {
+                continue
+            }
+
+            if (counter++ > 1000) {
+                break // Prevent insane CPU usage
+            }
+
+            prefixResult.addElement(
+                PrioritizedLookupElement.withPriority(
+                    LookupElementBuilder.create(key).withIcon(PlatformAssets.MINECRAFT_ICON),
+                    1.0 + key.getValue(text)
+                )
+            )
+        }
+    }
+
+    private fun String.getValue(text: String): Int {
+        if (this == text) {
+            return 1_000_000 // exact match
+        }
+
+        val lowerCaseThis = this.toLowerCase()
+        val lowerCaseText = text.toLowerCase()
+
+        if (lowerCaseThis == lowerCaseText) {
+            return 100_000 // lowercase exact match
+        }
+
+        val distance = Math.min(lowerCaseThis.length, lowerCaseText.length)
+        for (i in 0 until distance) {
+            if (lowerCaseThis[i] != lowerCaseText[i]) {
+                return i
+            }
+        }
+        return distance
+    }
+
+    companion object {
+        val KEY_PATTERN = psiElement().withElementType(elementType().oneOf(I18nTypes.KEY))
+        val DUMMY_PATTERN = psiElement().withElementType(elementType().oneOf(I18nTypes.DUMMY))
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/i18n/lang/I18nCompletionContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/i18n/lang/I18nCompletionContributor.kt
@@ -24,7 +24,6 @@ import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.codeInsight.completion.CompletionUtil
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.openapi.util.io.FileUtil
 import com.intellij.patterns.PlatformPatterns.elementType
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.psi.PsiElement

--- a/src/main/kotlin/com/demonwav/mcdev/i18n/reference/I18nReferenceCompletionConfidence.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/i18n/reference/I18nReferenceCompletionConfidence.kt
@@ -1,0 +1,27 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.i18n.reference
+
+import com.intellij.codeInsight.completion.CompletionConfidence
+import com.intellij.codeInsight.completion.SkipAutopopupInStrings
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.util.ThreeState
+
+class I18nReferenceCompletionConfidence : CompletionConfidence() {
+    override fun shouldSkipAutopopup(element: PsiElement, psiFile: PsiFile, offset: Int): ThreeState {
+        return if (SkipAutopopupInStrings.isInStringLiteral(element) && element.parent.references.any { it is I18nReference }) {
+            ThreeState.NO
+        } else {
+            ThreeState.UNSURE
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/at/completion/AtCompletionContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/at/completion/AtCompletionContributor.kt
@@ -20,6 +20,7 @@ import com.demonwav.mcdev.platform.mcp.at.gen.psi.AtFunction
 import com.demonwav.mcdev.platform.mcp.at.gen.psi.AtTypes
 import com.demonwav.mcdev.util.anonymousElements
 import com.demonwav.mcdev.util.fullQualifiedName
+import com.demonwav.mcdev.util.getSimilarity
 import com.demonwav.mcdev.util.nameAndParameterTypes
 import com.demonwav.mcdev.util.qualifiedMemberReference
 import com.demonwav.mcdev.util.simpleQualifiedMemberReference
@@ -293,24 +294,7 @@ class AtCompletionContributor : CompletionContributor() {
 
         val thisName = this.substringAfterLast('.')
 
-        if (thisName == text) {
-            return 1_000_000 + packageBonus // exact match
-        }
-
-        val lowerCaseThis = thisName.toLowerCase()
-        val lowerCaseText = text.toLowerCase()
-
-        if (lowerCaseThis == lowerCaseText) {
-            return 100_000 + packageBonus // lowercase exact match
-        }
-
-        val distance = Math.min(lowerCaseThis.length, lowerCaseText.length)
-        for (i in 0 until distance) {
-            if (lowerCaseThis[i] != lowerCaseText[i]) {
-                return i + packageBonus
-            }
-        }
-        return distance + packageBonus
+        return thisName.getSimilarity(text, packageBonus)
     }
 
     companion object {

--- a/src/main/kotlin/com/demonwav/mcdev/util/utils.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/utils.kt
@@ -164,3 +164,24 @@ inline fun String.span(predicate: (Char) -> Boolean): Pair<String, String> {
     val prefix = takeWhile(predicate)
     return prefix to drop(prefix.length)
 }
+
+fun String.getSimilarity(text: String, bonus: Int = 0): Int {
+    if (this == text) {
+        return 1_000_000 + bonus// exact match
+    }
+
+    val lowerCaseThis = this.toLowerCase()
+    val lowerCaseText = text.toLowerCase()
+
+    if (lowerCaseThis == lowerCaseText) {
+        return 100_000 + bonus // lowercase exact match
+    }
+
+    val distance = Math.min(lowerCaseThis.length, lowerCaseText.length)
+    for (i in 0 until distance) {
+        if (lowerCaseThis[i] != lowerCaseText[i]) {
+            return i + bonus
+        }
+    }
+    return distance + bonus
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -131,6 +131,7 @@
         </intentionAction>
         <codeFoldingOptionsProvider instance="com.demonwav.mcdev.i18n.I18nCodeFoldingOptionsProvider"/>
         <applicationService serviceImplementation="com.demonwav.mcdev.i18n.I18nFoldingSettings"/>
+        <completion.contributor language="I18n" implementationClass="com.demonwav.mcdev.i18n.lang.I18nCompletionContributor" />
 
         <applicationService serviceImplementation="com.demonwav.mcdev.MinecraftSettings"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -132,6 +132,8 @@
         <codeFoldingOptionsProvider instance="com.demonwav.mcdev.i18n.I18nCodeFoldingOptionsProvider"/>
         <applicationService serviceImplementation="com.demonwav.mcdev.i18n.I18nFoldingSettings"/>
         <completion.contributor language="I18n" implementationClass="com.demonwav.mcdev.i18n.lang.I18nCompletionContributor" />
+        <completion.confidence language="JAVA" implementationClass="com.demonwav.mcdev.i18n.reference.I18nReferenceCompletionConfidence"
+                               order="before javaSkipAutopopupInStrings"/>
 
         <applicationService serviceImplementation="com.demonwav.mcdev.MinecraftSettings"/>
 


### PR DESCRIPTION
This resolves #347. The auto-completion will suggest keys not yet in a localization that exist in the default language file (of that domain).

I mostly modelled this after the auto-completion provider for ATs, so similarities might be noticeable :P