### PR TITLE
ItemStack inspections

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/inspections/StackEmptyInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/inspections/StackEmptyInspection.kt
@@ -1,0 +1,100 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2018 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.forge.inspections
+
+import com.demonwav.mcdev.util.fullQualifiedName
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.*
+import com.siyeh.ig.BaseInspection
+import com.siyeh.ig.BaseInspectionVisitor
+import com.siyeh.ig.InspectionGadgetsFix
+import org.jetbrains.annotations.Nls
+
+class StackEmptyInspection : BaseInspection() {
+    companion object {
+        const val STACK_FQ_NAME = "net.minecraft.item.ItemStack"
+        const val EMPTY_NAME = "EMPTY"
+    }
+
+    @Nls
+    override fun getDisplayName() = "ItemStack comparison through ItemStack.EMPTY"
+
+    override fun buildErrorString(vararg infos: Any): String {
+        val compareExpression = infos[0] as PsiExpression
+        return "\"${compareExpression.text}\" compared with ItemStack.EMPTY"
+    }
+
+    override fun getStaticDescription() =
+            "Comparing an ItemStack to ItemStack.EMPTY to query stack emptiness can cause unwanted issues." +
+                    "When a stack in an inventory is shrunk, the instance is not replaced with ItemStack.EMPTY, but" +
+                    " the stack should still be considered empty. Instead, isEmpty() should be called."
+
+    override fun buildFix(vararg infos: Any): InspectionGadgetsFix? {
+        return object : InspectionGadgetsFix() {
+            override fun getFamilyName() = "Replace with .isEmpty()"
+
+            override fun doFix(project: Project, descriptor: ProblemDescriptor) {
+                val compareExpression = infos[0] as PsiExpression
+                val binaryExpression = infos[2] as PsiBinaryExpression
+                val elementFactory = JavaPsiFacade.getElementFactory(project)
+
+                var expressionText = "${compareExpression.text}.isEmpty()"
+
+                // If we were checking for != ItemStack.EMPTY, use !stack.isEmpty()
+                if (binaryExpression.operationSign.tokenType == JavaTokenType.NE) {
+                    expressionText = "!$expressionText"
+                }
+
+                val replacedExpression = elementFactory.createExpressionFromText(expressionText, binaryExpression.context)
+                binaryExpression.replace(replacedExpression)
+            }
+        }
+    }
+
+    override fun buildVisitor(): BaseInspectionVisitor {
+        return object : BaseInspectionVisitor() {
+            override fun visitBinaryExpression(expression: PsiBinaryExpression) {
+                val operationType = expression.operationSign.tokenType
+
+                if (operationType == JavaTokenType.EQEQ || operationType == JavaTokenType.NE) {
+                    val leftExpression = expression.lOperand
+                    val rightExpression = expression.rOperand
+
+                    // Check if both operands evaluate to an ItemStack
+                    if (isExpressionStack(leftExpression) && isExpressionStack(rightExpression)) {
+                        val leftEmpty = isExpressionEmptyConstant(leftExpression)
+                        val rightEmpty = isExpressionEmptyConstant(rightExpression)
+
+                        // Check that only one of the references are ItemStack.EMPTY
+                        if (leftEmpty xor rightEmpty) {
+                            // The other operand will be the stack
+                            val compareExpression = if (leftEmpty) rightExpression else leftExpression
+                            val emptyReference = if (leftEmpty) leftExpression else rightExpression
+
+                            registerError(expression, compareExpression, emptyReference, expression)
+                        }
+                    }
+                }
+            }
+
+            private fun isExpressionStack(expression: PsiExpression?): Boolean {
+                return (expression?.type as? PsiClassType)?.resolve()?.fullQualifiedName == STACK_FQ_NAME
+            }
+
+            private fun isExpressionEmptyConstant(expression: PsiExpression?): Boolean {
+                val reference = expression as? PsiReferenceExpression
+                val field = reference?.resolve() as? PsiField ?: return false
+                return field.name == EMPTY_NAME && field.containingClass?.fullQualifiedName == STACK_FQ_NAME
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/inspections/StackEmptyInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/inspections/StackEmptyInspection.kt
@@ -8,7 +8,7 @@
  * MIT License
  */
 
-package com.demonwav.mcdev.platform.forge.inspections
+package com.demonwav.mcdev.platform.mcp.inspections
 
 import com.demonwav.mcdev.util.fullQualifiedName
 import com.intellij.codeInspection.ProblemDescriptor
@@ -91,8 +91,8 @@ class StackEmptyInspection : BaseInspection() {
             }
 
             private fun isExpressionEmptyConstant(expression: PsiExpression?): Boolean {
-                val reference = expression as? PsiReferenceExpression
-                val field = reference?.resolve() as? PsiField ?: return false
+                val reference = expression as? PsiReferenceExpression ?: return false
+                val field = reference.resolve() as? PsiField ?: return false
                 return field.name == EMPTY_NAME && field.containingClass?.fullQualifiedName == STACK_FQ_NAME
             }
         }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/inspections/StackEmptyInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/inspections/StackEmptyInspection.kt
@@ -10,10 +10,22 @@
 
 package com.demonwav.mcdev.platform.mcp.inspections
 
+import com.demonwav.mcdev.facet.MinecraftFacet
+import com.demonwav.mcdev.platform.mcp.McpModuleType
+import com.demonwav.mcdev.platform.mcp.srg.SrgMemberReference
+import com.demonwav.mcdev.util.MemberReference
+import com.demonwav.mcdev.util.findModule
 import com.demonwav.mcdev.util.fullQualifiedName
 import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
-import com.intellij.psi.*
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.JavaTokenType
+import com.intellij.psi.PsiBinaryExpression
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiReferenceExpression
 import com.siyeh.ig.BaseInspection
 import com.siyeh.ig.BaseInspectionVisitor
 import com.siyeh.ig.InspectionGadgetsFix
@@ -22,7 +34,9 @@ import org.jetbrains.annotations.Nls
 class StackEmptyInspection : BaseInspection() {
     companion object {
         const val STACK_FQ_NAME = "net.minecraft.item.ItemStack"
-        const val EMPTY_NAME = "EMPTY"
+        val STACK_JVM_NAME = STACK_FQ_NAME.replace('.', '/')
+        val EMPTY_SRG = SrgMemberReference.parse("$STACK_JVM_NAME/field_190927_a")
+        val IS_EMPTY_SRG = SrgMemberReference.parse("$STACK_JVM_NAME/func_190926_b")
     }
 
     @Nls
@@ -47,7 +61,9 @@ class StackEmptyInspection : BaseInspection() {
                 val binaryExpression = infos[2] as PsiBinaryExpression
                 val elementFactory = JavaPsiFacade.getElementFactory(project)
 
-                var expressionText = "${compareExpression.text}.isEmpty()"
+                val mappedIsEmpty = compareExpression.findModule()?.getMappedMethod(IS_EMPTY_SRG)?.name ?: "isEmpty"
+
+                var expressionText = "${compareExpression.text}.$mappedIsEmpty()"
 
                 // If we were checking for != ItemStack.EMPTY, use !stack.isEmpty()
                 if (binaryExpression.operationSign.tokenType == JavaTokenType.NE) {
@@ -93,8 +109,19 @@ class StackEmptyInspection : BaseInspection() {
             private fun isExpressionEmptyConstant(expression: PsiExpression?): Boolean {
                 val reference = expression as? PsiReferenceExpression ?: return false
                 val field = reference.resolve() as? PsiField ?: return false
-                return field.name == EMPTY_NAME && field.containingClass?.fullQualifiedName == STACK_FQ_NAME
+                val mappedEmpty = field.findModule()?.getMappedField(EMPTY_SRG)?.name ?: "EMPTY"
+                return field.name == mappedEmpty && field.containingClass?.fullQualifiedName == STACK_FQ_NAME
             }
         }
+    }
+
+    private fun Module.getMappedMethod(reference: MemberReference): MemberReference? {
+        val srgManager = MinecraftFacet.getInstance(this, McpModuleType)?.srgManager
+        return srgManager?.srgMapNow?.mapToMcpMethod(reference)
+    }
+
+    private fun Module.getMappedField(reference: MemberReference): MemberReference? {
+        val srgManager = MinecraftFacet.getInstance(this, McpModuleType)?.srgManager
+        return srgManager?.srgMapNow?.mapToMcpField(reference)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -376,13 +376,6 @@
                          level="ERROR"
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.platform.forge.inspections.sideonly.LocalVariableDeclarationSideOnlyInspection"/>
-        <localInspection displayName="Invalid empty ItemStack comparison with ItemStack.EMPTY"
-                         groupName="Minecraft Forge"
-                         language="JAVA"
-                         enabledByDefault="false"
-                         level="WARNING"
-                         hasStaticDescription="true"
-                         implementationClass="com.demonwav.mcdev.platform.forge.inspections.StackEmptyInspection"/>
         <!--endregion-->
 
         <!--region MCP INSPECTIONS-->
@@ -400,6 +393,13 @@
                          level="WARNING"
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.platform.mcp.at.AtUsageInspection"/>
+        <localInspection displayName="Invalid empty ItemStack comparison with ItemStack.EMPTY"
+                         groupName="MCP"
+                         language="JAVA"
+                         enabledByDefault="false"
+                         level="WARNING"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mcp.inspections.StackEmptyInspection"/>
         <!--endregion-->
 
         <!--region MIXIN INSPECTIONS-->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -376,6 +376,13 @@
                          level="ERROR"
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.platform.forge.inspections.sideonly.LocalVariableDeclarationSideOnlyInspection"/>
+        <localInspection displayName="Invalid empty ItemStack comparison with ItemStack.EMPTY"
+                         groupName="Minecraft Forge"
+                         language="JAVA"
+                         enabledByDefault="false"
+                         level="WARNING"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.forge.inspections.StackEmptyInspection"/>
         <!--endregion-->
 
         <!--region MCP INSPECTIONS-->


### PR DESCRIPTION
This PR implements an inspection around ItemStack comparison with `ItemStack.EMPTY`. Doing this might not always give desired result, as when depleting a stack, the instance is not replaced with ItemStack.EMPTY. Instead `ItemStack.isEmpty()` should be used. This is a common mistake made when porting mods from 1.10, where stacks were nullable.

Inspection and fix visible here:
https://streamable.com/vy53o

Are there any other ItemStack related inspections that would fit within the scope of this PR?