### PR TITLE
Turn createDependencyReducedPom off for Bukkit, Bungee & Canary Maven templates

### DIFF
--- a/src/main/resources/fileTemplates/j2ee/bukkit_pom_template.xml.ft
+++ b/src/main/resources/fileTemplates/j2ee/bukkit_pom_template.xml.ft
@@ -38,6 +38,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <minimizeJar>true</minimizeJar>
             </configuration>
           </execution>

--- a/src/main/resources/fileTemplates/j2ee/bungeecord_pom_template.xml.ft
+++ b/src/main/resources/fileTemplates/j2ee/bungeecord_pom_template.xml.ft
@@ -38,6 +38,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <minimizeJar>true</minimizeJar>
             </configuration>
           </execution>

--- a/src/main/resources/fileTemplates/j2ee/canary_pom_template.xml.ft
+++ b/src/main/resources/fileTemplates/j2ee/canary_pom_template.xml.ft
@@ -38,6 +38,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <minimizeJar>true</minimizeJar>
             </configuration>
           </execution>


### PR DESCRIPTION
`<createDependencyReducedPom>` is an utterly useless Shade configuration option that is enabled by default. Having it on runs the risk of having IntelliJ very, very confused about the Maven projects in a given project. When it does mess IJ up, libraries aren't indexed and there are import errors everywhere. Took me a bit of debugging to figure out that that wasn't turned off by default.