### PR TITLE
Add Sponge plugin class inspections

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     testLibs("org.jetbrains.idea:mockJDK:1.7-4d76c50")
     testLibs("org.spongepowered:mixin:0.7-SNAPSHOT:thin")
     testLibs("com.demonwav.mcdev:all-types-nbt:1.0@nbt")
+    testLibs("org.spongepowered:spongeapi:7.0.0:shaded")
 
     // For non-SNAPSHOT versions (unless Jetbrains fixes this...) find the version with:
     // println(intellij.ideaDependency.buildNumber.substring(intellij.type.length + 1))

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/insight/SpongeImplicitUsageProvider.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/insight/SpongeImplicitUsageProvider.kt
@@ -1,0 +1,39 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2019 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge.insight
+
+import com.demonwav.mcdev.platform.sponge.util.isInSpongePluginClass
+import com.demonwav.mcdev.platform.sponge.util.isInjected
+import com.intellij.codeInsight.daemon.ImplicitUsageProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+
+class SpongeImplicitUsageProvider : ImplicitUsageProvider {
+    override fun isImplicitWrite(element: PsiElement): Boolean = isPluginClassInjectedField(element, false)
+
+    override fun isImplicitRead(element: PsiElement): Boolean = false
+
+    override fun isImplicitUsage(element: PsiElement): Boolean =
+        isPluginClassEmptyConstructor(element) || isPluginClassInjectedSetter(element)
+
+    override fun isImplicitlyNotNullInitialized(element: PsiElement): Boolean =
+        isPluginClassInjectedField(element, true)
+
+    private fun isPluginClassEmptyConstructor(element: PsiElement): Boolean =
+        element is PsiMethod && element.isInSpongePluginClass() && element.isConstructor && !element.hasParameters()
+
+    private fun isPluginClassInjectedField(element: PsiElement, optionalSensitive: Boolean): Boolean =
+        element is PsiField && element.isInSpongePluginClass() && isInjected(element, optionalSensitive)
+
+    private fun isPluginClassInjectedSetter(element: PsiElement): Boolean =
+        element is PsiMethod && element.isInSpongePluginClass() && isInjected(element, false)
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongeInjectionInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongeInjectionInspection.kt
@@ -1,0 +1,418 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2019 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge.inspection
+
+import com.demonwav.mcdev.platform.sponge.SpongeModuleType
+import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
+import com.demonwav.mcdev.platform.sponge.util.isInSpongePluginClass
+import com.demonwav.mcdev.platform.sponge.util.isInjectOptional
+import com.demonwav.mcdev.platform.sponge.util.spongePluginClassId
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.findModule
+import com.demonwav.mcdev.util.fullQualifiedName
+import com.intellij.codeInsight.intention.AddAnnotationFix
+import com.intellij.codeInsight.intention.QuickFixFactory
+import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.ide.util.PackageUtil
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiJavaCodeReferenceElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.psi.PsiVariable
+import com.intellij.psi.impl.source.PsiClassReferenceType
+import com.intellij.psi.util.createSmartPointer
+import com.siyeh.ig.BaseInspection
+import com.siyeh.ig.BaseInspection.formatString
+import com.siyeh.ig.ui.UiUtils
+import org.jdom.Element
+import javax.swing.JComponent
+
+class SpongeInjectionInspection : AbstractBaseJavaLocalInspectionTool() {
+
+    private val injectableTypesList = defaultInjectableTypes.toMutableList()
+
+    @JvmField
+    var injectableTypes: String = serializedDefaultInjectableTypes
+
+    override fun getStaticDescription() = "Invalid @Inject usage in Sponge plugin class."
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return if (SpongeModuleType.isInModule(holder.file)) {
+            Visitor(holder)
+        } else {
+            PsiElementVisitor.EMPTY_VISITOR
+        }
+    }
+
+    override fun processFile(file: PsiFile, manager: InspectionManager): List<ProblemDescriptor> {
+        return if (SpongeModuleType.isInModule(file)) {
+            super.processFile(file, manager)
+        } else {
+            emptyList()
+        }
+    }
+
+    private inner class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+
+        override fun visitField(field: PsiField) {
+            if (!field.hasAnnotation(SpongeConstants.INJECT_ANNOTATION) || !field.isInSpongePluginClass()) {
+                return
+            }
+
+            checkInjection(field, field)
+        }
+
+        override fun visitMethod(method: PsiMethod) {
+            if (!method.hasAnnotation(SpongeConstants.INJECT_ANNOTATION) || !method.isInSpongePluginClass()) {
+                return
+            }
+
+            if (method.isConstructor) {
+                val annotation = method.getAnnotation(SpongeConstants.INJECT_ANNOTATION)
+                if (annotation != null && isInjectOptional(annotation)) {
+                    holder.registerProblem(
+                        annotation.parameterList,
+                        "Constructor injection cannot be optional.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        RemoveAnnotationParameters(annotation, "Remove 'optional' parameter")
+                    )
+                }
+            }
+
+            method.parameterList.parameters.forEach { variable -> this.checkInjection(variable, variable) }
+        }
+
+        private fun checkInjection(variable: PsiVariable, annotationsOwner: PsiModifierListOwner) {
+            val typeElement = variable.typeElement ?: return
+            if (variable.type is PsiPrimitiveType) {
+                holder.registerProblem(
+                    typeElement,
+                    "Primitive types cannot be injected by Sponge.",
+                    ProblemHighlightType.GENERIC_ERROR
+                )
+                return
+            }
+
+            val classType = variable.type as? PsiClassReferenceType ?: return
+            val name = classType.fullQualifiedName ?: return
+
+            // Check if injection is possible with the current type
+            if (name !in injectableTypesList) {
+                holder.registerProblem(
+                    typeElement,
+                    "${classType.presentableText} cannot be injected by Sponge.",
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    AddToKnownInjectableTypes(name)
+                )
+                return
+            }
+
+            if (name == "org.spongepowered.api.asset.Asset") {
+                val assetId = variable.getAnnotation(SpongeConstants.ASSET_ID_ANNOTATION)
+                if (assetId == null) {
+                    holder.registerProblem(
+                        variable.nameIdentifier ?: variable,
+                        "Injected Assets must be annotated with @AssetId.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        AddAnnotationFix(SpongeConstants.ASSET_ID_ANNOTATION, annotationsOwner)
+                    )
+                } else {
+                    variable.findModule()?.let { module ->
+                        val assetPathAttributeValue = assetId.findAttributeValue(null)
+                        val assetPath = assetPathAttributeValue?.constantStringValue?.replace('\\', '/') ?: return@let
+
+                        val pluginId = variable.spongePluginClassId() ?: return@let
+                        val relativeAssetPath = "assets/$pluginId/$assetPath"
+
+                        val roots = ModuleRootManager.getInstance(module).getSourceRoots(false)
+                        val pathIsDirectory = roots.any { root ->
+                            root.findFileByRelativePath(relativeAssetPath)?.isDirectory == true
+                        }
+                        if (pathIsDirectory || relativeAssetPath.endsWith('/')) {
+                            holder.registerProblem(
+                                assetPathAttributeValue,
+                                "AssetId must point to a file.",
+                                ProblemHighlightType.GENERIC_ERROR
+                            )
+                            return@let
+                        }
+
+                        if (roots.none { it.findFileByRelativePath(relativeAssetPath) != null }) {
+                            val fix = roots.firstOrNull()?.let { contentRoot ->
+                                variable.manager.findDirectory(contentRoot)?.let { directory ->
+                                    CreateAssetFileFix(assetPath, module, pluginId, directory)
+                                }
+                            }
+
+                            holder.registerProblem(
+                                assetPathAttributeValue,
+                                "Asset '$assetPath' does not exist.",
+                                ProblemHighlightType.GENERIC_ERROR,
+                                fix
+                            )
+                        }
+                    }
+                }
+            }
+
+            // @ConfigDir and @DefaultConfig usages
+            val configDir = variable.getAnnotation(SpongeConstants.CONFIG_DIR_ANNOTATION)
+            val defaultConfig = variable.getAnnotation(SpongeConstants.DEFAULT_CONFIG_ANNOTATION)
+            if (name == "java.io.File" || name == "java.nio.file.Path") {
+                if (configDir != null && defaultConfig != null) {
+                    val quickFixFactory = QuickFixFactory.getInstance()
+                    holder.registerProblem(
+                        variable.nameIdentifier ?: variable,
+                        "@ConfigDir and @DefaultConfig cannot be used on the same field.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        quickFixFactory.createDeleteFix(configDir, "Remove @ConfigDir"),
+                        quickFixFactory.createDeleteFix(defaultConfig, "Remove @DefaultConfig")
+                    )
+                } else if (configDir == null && defaultConfig == null) {
+                    holder.registerProblem(
+                        variable.nameIdentifier ?: variable,
+                        "An injected ${classType.name} must be annotated with either @ConfigDir or @DefaultConfig.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        AddAnnotationFix(SpongeConstants.CONFIG_DIR_ANNOTATION, annotationsOwner),
+                        AddAnnotationFix(SpongeConstants.DEFAULT_CONFIG_ANNOTATION, annotationsOwner)
+                    )
+                }
+            } else if (name == "ninja.leaping.configurate.loader.ConfigurationLoader") {
+                if (defaultConfig == null) {
+                    holder.registerProblem(
+                        variable.nameIdentifier ?: variable,
+                        "Injected ConfigurationLoader must be annotated with @DefaultConfig.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        AddAnnotationFix(SpongeConstants.DEFAULT_CONFIG_ANNOTATION, annotationsOwner)
+                    )
+                }
+
+                if (configDir != null) {
+                    holder.registerProblem(
+                        configDir,
+                        "Injected ConfigurationLoader cannot be annotated with @ConfigDir.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        QuickFixFactory.getInstance().createDeleteFix(configDir, "Remove @ConfigDir")
+                    )
+                }
+
+                if (classType.isRaw) {
+                    val ref = classType.reference
+                    holder.registerProblem(
+                        ref,
+                        "Injected ConfigurationLoader must have a generic parameter.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        MissingConfLoaderTypeParamFix(ref)
+                    )
+                } else {
+                    classType.parameters.firstOrNull()?.let { param ->
+                        val paramType = param as? PsiClassReferenceType ?: return@let
+                        val paramTypeFQName = paramType.fullQualifiedName ?: return@let
+                        if (paramTypeFQName != "ninja.leaping.configurate.commented.CommentedConfigurationNode") {
+                            val ref = param.reference
+                            holder.registerProblem(
+                                ref,
+                                "Injected ConfigurationLoader generic parameter must be CommentedConfigurationNode.",
+                                ProblemHighlightType.GENERIC_ERROR,
+                                WrongConfLoaderTypeParamFix(ref)
+                            )
+                        }
+                    }
+                }
+            } else {
+                val quickFixFactory = QuickFixFactory.getInstance()
+                if (configDir != null) {
+                    holder.registerProblem(
+                        configDir,
+                        "${classType.name} cannot be annotated with @ConfigDir.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        quickFixFactory.createDeleteFix(configDir, "Remove @ConfigDir")
+                    )
+                }
+
+                if (defaultConfig != null) {
+                    holder.registerProblem(
+                        defaultConfig,
+                        "${classType.name} cannot be annotated with @DefaultConfig.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        quickFixFactory.createDeleteFix(defaultConfig, "Remove @DefaultConfig")
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+
+        val defaultInjectableTypes = listOf(
+            // https://github.com/SpongePowered/SpongeCommon/blob/f92cef4/src/main/java/org/spongepowered/common/inject/SpongeImplementationModule.java
+            "org.spongepowered.api.Game",
+            "org.spongepowered.api.MinecraftVersion",
+            "org.spongepowered.api.service.ServiceManager",
+            "org.spongepowered.api.asset.AssetManager",
+            "org.spongepowered.api.GameRegistry",
+            "org.spongepowered.api.world.TeleportHelper",
+            "org.spongepowered.api.scheduler.Scheduler",
+            "org.spongepowered.api.command.CommandManager",
+            "org.spongepowered.api.data.DataManager",
+            "org.spongepowered.api.config.ConfigManager",
+            "org.spongepowered.api.data.property.PropertyRegistry",
+            "org.spongepowered.api.event.CauseStackManager",
+            "org.spongepowered.api.util.metric.MetricsConfigManager",
+            "org.spongepowered.api.Platform",
+            "org.spongepowered.api.plugin.PluginManager",
+            "org.spongepowered.api.event.EventManager",
+            "org.spongepowered.api.network.ChannelRegistrar",
+            "org.slf4j.Logger",
+            // https://github.com/SpongePowered/SpongeCommon/blob/855ffc1/src/main/java/org/spongepowered/common/inject/SpongeModule.java
+            "java.io.File",
+            "java.nio.file.Path",
+            "ninja.leaping.configurate.loader.ConfigurationLoader",
+
+            "ninja.leaping.configurate.objectmapping.GuiceObjectMapperFactory",
+            "com.google.inject.Injector",
+            "org.spongepowered.api.plugin.PluginContainer",
+            "org.spongepowered.api.asset.Asset"
+        )
+
+        val serializedDefaultInjectableTypes: String = formatString(defaultInjectableTypes)
+    }
+
+    class RemoveAnnotationParameters(annotation: PsiAnnotation, val txt: String) :
+        LocalQuickFixOnPsiElement(annotation) {
+
+        override fun getFamilyName(): String = name
+
+        override fun getText(): String = txt
+
+        override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+            val newAnnotation = JavaPsiFacade.getElementFactory(project)
+                .createAnnotationFromText("@" + (startElement as PsiAnnotation).qualifiedName, startElement.parent)
+            startElement.replace(newAnnotation)
+        }
+    }
+
+    class WrongConfLoaderTypeParamFix(ref: PsiJavaCodeReferenceElement) : LocalQuickFixOnPsiElement(ref) {
+
+        override fun getFamilyName(): String = name
+
+        override fun getText(): String = "Set to CommentedConfigurationNode"
+
+        override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+            val newRef = JavaPsiFacade.getElementFactory(project).createReferenceFromText(
+                "ninja.leaping.configurate.commented.CommentedConfigurationNode",
+                startElement
+            )
+            startElement.replace(newRef)
+        }
+    }
+
+    class MissingConfLoaderTypeParamFix(ref: PsiJavaCodeReferenceElement) : LocalQuickFixOnPsiElement(ref) {
+
+        override fun getFamilyName(): String = name
+
+        override fun getText(): String = "Insert generic parameter"
+
+        override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+            val newRef = JavaPsiFacade.getElementFactory(project).createReferenceFromText(
+                "ninja.leaping.configurate.loader.ConfigurationLoader" +
+                    "<ninja.leaping.configurate.commented.CommentedConfigurationNode>",
+                startElement
+            )
+            startElement.replace(newRef)
+        }
+    }
+
+    class CreateAssetFileFix(
+        private val assetPath: String,
+        private val module: Module,
+        private val pluginId: String,
+        directory: PsiDirectory
+    ) : LocalQuickFix {
+
+        private val dirPointer = directory.createSmartPointer()
+
+        override fun getFamilyName(): String = "Create asset file"
+
+        override fun startInWriteAction(): Boolean = false
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val index = assetPath.lastIndexOf('/')
+            val assetDir = if (index > 0)
+                "." + assetPath.substring(0, index).replace('/', '.')
+            else ""
+            val fileName = assetPath.substring(index + 1)
+            val createdDir = PackageUtil.findOrCreateDirectoryForPackage(
+                module,
+                "assets.$pluginId$assetDir",
+                dirPointer.element,
+                false
+            )
+            val createdFile = runWriteAction {
+                createdDir?.createFile(fileName)
+            } ?: return
+            if (createdFile.canNavigate()) {
+                createdFile.navigate(true)
+            }
+        }
+    }
+
+    inner class AddToKnownInjectableTypes(private val typeFqn: String) : LocalQuickFix {
+        override fun getFamilyName(): String = "Add to known injectable types"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            injectableTypesList.add(typeFqn)
+        }
+    }
+
+    override fun createOptionsPanel(): JComponent? {
+        val chooserList = UiUtils.createTreeClassChooserList(
+            injectableTypesList,
+            "Injectable types",
+            "Choose injectable type"
+        )
+        UiUtils.setComponentSize(chooserList, 7, 25)
+        return chooserList
+    }
+
+    override fun readSettings(node: Element) {
+        super.readSettings(node)
+        BaseInspection.parseString(injectableTypes, injectableTypesList)
+    }
+
+    override fun writeSettings(node: Element) {
+        injectableTypes = if (injectableTypesList.isEmpty()) {
+            serializedDefaultInjectableTypes
+        } else {
+            formatString(injectableTypesList)
+        }
+
+        super.writeSettings(node)
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongePluginClassInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongePluginClassInspection.kt
@@ -1,0 +1,115 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2019 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge.inspection
+
+import com.demonwav.mcdev.platform.sponge.SpongeModuleType
+import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
+import com.demonwav.mcdev.platform.sponge.util.isSpongePluginClass
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.codeInsight.daemon.impl.quickfix.AddDefaultConstructorFix
+import com.intellij.codeInsight.daemon.impl.quickfix.ModifierFix
+import com.intellij.codeInsight.intention.QuickFixFactory
+import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.lang.jvm.JvmModifier
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiModifier
+
+class SpongePluginClassInspection : AbstractBaseJavaLocalInspectionTool() {
+
+    override fun getStaticDescription() = "Checks the plugin class is valid."
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return if (SpongeModuleType.isInModule(holder.file)) {
+            Visitor(holder)
+        } else {
+            PsiElementVisitor.EMPTY_VISITOR
+        }
+    }
+
+    override fun processFile(file: PsiFile, manager: InspectionManager): List<ProblemDescriptor> {
+        return if (SpongeModuleType.isInModule(file)) {
+            super.processFile(file, manager)
+        } else {
+            emptyList()
+        }
+    }
+
+    class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+        override fun visitClass(aClass: PsiClass) {
+            if (!aClass.isSpongePluginClass()) {
+                return
+            }
+
+            val ctorInjectAnnos = aClass.constructors.mapNotNull {
+                val annotation = it.getAnnotation(SpongeConstants.INJECT_ANNOTATION) ?: return@mapNotNull null
+                it to annotation
+            }
+            if (ctorInjectAnnos.size > 1) {
+                val quickFixFactory = QuickFixFactory.getInstance()
+                ctorInjectAnnos.forEach { (injectedMethod, injectAnno) ->
+                    holder.registerProblem(
+                        injectAnno,
+                        "There can only be one injected constructor.",
+                        quickFixFactory.createDeleteFix(injectAnno, "Remove this @Inject"),
+                        quickFixFactory.createDeleteFix(injectedMethod, "Remove this injected constructor")
+                    )
+                }
+            }
+            val hasInjectedCtor = ctorInjectAnnos.isNotEmpty()
+
+            val emptyCtor = aClass.constructors.find { !it.hasParameters() }
+            if (emptyCtor == null && !hasInjectedCtor) {
+                val classIdentifier = aClass.nameIdentifier
+                if (classIdentifier != null) {
+                    holder.registerProblem(
+                        classIdentifier,
+                        "Plugin class must have an empty constructor or an @Inject constructor.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        AddDefaultConstructorFix(aClass)
+                    )
+                }
+            }
+
+            if (!hasInjectedCtor && emptyCtor != null && emptyCtor.hasModifier(JvmModifier.PRIVATE)) {
+                val ctorIdentifier = emptyCtor.nameIdentifier
+                if (ctorIdentifier != null) {
+                    holder.registerProblem(
+                        ctorIdentifier,
+                        "Plugin class empty constructor must not be private.",
+                        ProblemHighlightType.GENERIC_ERROR,
+                        ModifierFix(emptyCtor, PsiModifier.PACKAGE_LOCAL, true, false),
+                        ModifierFix(emptyCtor, PsiModifier.PROTECTED, true, false),
+                        ModifierFix(emptyCtor, PsiModifier.PUBLIC, true, false)
+                    )
+                }
+            }
+
+            aClass.getAnnotation(SpongeConstants.PLUGIN_ANNOTATION)?.let { pluginAnno ->
+                val pluginIdValue = pluginAnno.findAttributeValue("id") ?: return@let
+                val pluginId = pluginIdValue.constantStringValue ?: return@let
+                if (!SpongeConstants.ID_PATTERN.matcher(pluginId).matches()) {
+                    holder.registerProblem(
+                        pluginIdValue,
+                        "Plugin IDs should be lowercase, and only contain characters from a-z, dashes or underscores," +
+                            " start with a lowercase letter, and not exceed 64 characters."
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/util/SpongeConstants.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/util/SpongeConstants.kt
@@ -10,6 +10,8 @@
 
 package com.demonwav.mcdev.platform.sponge.util
 
+import java.util.regex.Pattern
+
 object SpongeConstants {
 
     const val PLUGIN_ANNOTATION = "org.spongepowered.api.plugin.Plugin"
@@ -21,4 +23,12 @@ object SpongeConstants {
     const val IS_CANCELLED_ANNOTATION = "org.spongepowered.api.event.filter.IsCancelled"
     const val CANCELLABLE = "org.spongepowered.api.event.Cancellable"
     const val EVENT_ISCANCELLED_METHOD_NAME = "isCancelled"
+    const val DEFAULT_CONFIG_ANNOTATION = "org.spongepowered.api.config.DefaultConfig"
+    const val CONFIG_DIR_ANNOTATION = "org.spongepowered.api.config.ConfigDir"
+    const val ASSET_ID_ANNOTATION = "org.spongepowered.api.asset.AssetId"
+    const val INJECT_ANNOTATION = "com.google.inject.Inject"
+
+    // Taken from https://github.com/SpongePowered/plugin-meta/blob/185f5c2/src/main/java/org/spongepowered/plugin/meta/PluginMetadata.java#L60
+    val ID_PATTERN_STRING = "^[a-z][a-z0-9-_]{1,63}$"
+    val ID_PATTERN = Pattern.compile(ID_PATTERN_STRING)
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/util/SpongeUtils.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/util/SpongeUtils.kt
@@ -1,0 +1,42 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2019 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge.util
+
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.findContainingClass
+import com.intellij.lang.jvm.annotation.JvmAnnotationConstantValue
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiModifierListOwner
+
+fun PsiMember.isInSpongePluginClass(): Boolean = this.containingClass?.isSpongePluginClass() == true
+
+fun PsiClass.isSpongePluginClass(): Boolean = this.hasAnnotation(SpongeConstants.PLUGIN_ANNOTATION)
+
+fun PsiElement.spongePluginClassId(): String? = this.findContainingClass()
+    ?.getAnnotation(SpongeConstants.PLUGIN_ANNOTATION)?.findAttributeValue("id")?.constantStringValue
+
+fun isInjected(element: PsiModifierListOwner, optionalSensitive: Boolean): Boolean {
+    val annotation = element.getAnnotation(SpongeConstants.INJECT_ANNOTATION) ?: return false
+    if (!optionalSensitive) {
+        return true
+    }
+
+    return !isInjectOptional(annotation)
+}
+
+fun isInjectOptional(annotation: PsiAnnotation): Boolean {
+    val optional = annotation.findAttribute("optional") ?: return false
+    val value = optional.attributeValue
+    return value is JvmAnnotationConstantValue && value.constantValue == true
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -157,6 +157,8 @@
         <!-- Sponge Line Marker Provider -->
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.platform.sponge.color.SpongeColorLineMarkerProvider"/>
 
+        <implicitUsageProvider implementation="com.demonwav.mcdev.platform.sponge.insight.SpongeImplicitUsageProvider" />
+
         <!-- Sponge Annotator -->
         <annotator language="JAVA" implementationClass="com.demonwav.mcdev.platform.sponge.color.SpongeColorAnnotator"/>
 
@@ -340,6 +342,21 @@
                          level="ERROR"
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.platform.sponge.inspection.SpongeWrongGetterTypeInspection"/>
+
+        <localInspection displayName="Invalid @Inject usage in Sponge plugin class"
+                         groupName="Minecraft Sponge"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.sponge.inspection.SpongeInjectionInspection"/>
+        <localInspection displayName="Sponge plugin class validity"
+                         groupName="Minecraft Sponge"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.sponge.inspection.SpongePluginClassInspection"/>
         <!--endregion-->
 
         <!--region FORGE INSPECTIONS-->

--- a/src/test/kotlin/com/demonwav/mcdev/framework/ProjectBuilder.kt
+++ b/src/test/kotlin/com/demonwav/mcdev/framework/ProjectBuilder.kt
@@ -64,7 +64,7 @@ class ProjectBuilder(fixture: JavaCodeInsightTestFixture, private val root: Virt
         intermediatePath = oldIntermediatePath
     }
 
-    private fun file(path: String, code: String, ext: String, configure: Boolean): VirtualFile {
+    fun file(path: String, code: String, ext: String, configure: Boolean): VirtualFile {
         check(path.endsWith(ext))
 
         val fullPath = if (intermediatePath.isEmpty()) path else "$intermediatePath/$path"

--- a/src/test/kotlin/com/demonwav/mcdev/platform/sponge/BaseSpongeTest.kt
+++ b/src/test/kotlin/com/demonwav/mcdev/platform/sponge/BaseSpongeTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2019 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge
+
+import com.demonwav.mcdev.framework.BaseMinecraftTest
+import com.demonwav.mcdev.framework.createLibrary
+import com.demonwav.mcdev.platform.PlatformType
+import com.demonwav.mcdev.util.runWriteTask
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.libraries.Library
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+
+abstract class BaseSpongeTest : BaseMinecraftTest(PlatformType.SPONGE) {
+
+    private var library: Library? = null
+
+    @BeforeEach
+    fun initSponge() {
+        runWriteTask {
+            library = createLibrary(project, "spongeapi")
+        }
+
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            model.addLibraryEntry(library ?: throw IllegalStateException("Library not created"))
+            val orderEntries = model.orderEntries
+            val last = orderEntries.last()
+            System.arraycopy(orderEntries, 0, orderEntries, 1, orderEntries.size - 1)
+            orderEntries[0] = last
+            model.rearrangeOrderEntries(orderEntries)
+        }
+    }
+
+    @AfterEach
+    fun cleanupSponge() {
+        library?.let { l ->
+            ModuleRootModificationUtil.updateModel(module) { model ->
+                model.removeOrderEntry(
+                    model.findLibraryOrderEntry(l) ?: throw IllegalStateException("Library not found")
+                )
+            }
+
+            runWriteTask {
+                val table = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+                table.modifiableModel.let { model ->
+                    model.removeLibrary(l)
+                    model.commit()
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/demonwav/mcdev/platform/sponge/PluginClassInspectionTest.kt
+++ b/src/test/kotlin/com/demonwav/mcdev/platform/sponge/PluginClassInspectionTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2019 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge
+
+import com.demonwav.mcdev.framework.EdtInterceptor
+import com.demonwav.mcdev.platform.sponge.inspection.SpongePluginClassInspection
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(EdtInterceptor::class)
+@DisplayName("Sponge Plugin Class Inspection Tests")
+class PluginClassInspectionTest : BaseSpongeTest() {
+
+    private fun doTest(@Language("JAVA") code: String) {
+        buildProject {
+            src {
+                java("test/ASpongePlugin.java", code)
+            }
+        }
+
+        fixture.enableInspections(SpongePluginClassInspection::class.java)
+        fixture.checkHighlighting(false, false, false)
+    }
+
+    @Test
+    @DisplayName("Invalid Plugin Id Test")
+    fun invalidPluginIdTest() {
+        doTest("""
+package test;
+
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = <error descr="Plugin IDs should be lowercase, and only contain characters from a-z, dashes or underscores, start with a lowercase letter, and not exceed 64 characters.">"a plugin"</error>)
+public class ASpongePlugin {
+    ASpongePlugin() {
+    }
+}
+""")
+    }
+
+    @Test
+    @DisplayName("No Empty Constructor Test")
+    fun noEmptyConstructorTest() {
+        doTest("""
+package test;
+
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class <error descr="Plugin class must have an empty constructor or an @Inject constructor.">ASpongePlugin</error> {
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Private Constructor Test")
+    fun privateConstructorTest() {
+        doTest("""
+package test;
+
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    private <error descr="Plugin class empty constructor must not be private.">ASpongePlugin</error>() {
+    }
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Private Constructor With Injected Constructor Test")
+    fun privateConstructorWithInjectedConstructorTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    private ASpongePlugin() {
+    }
+
+    @Inject
+    private ASpongePlugin(Logger logger) {
+    }
+}
+""")
+    }
+
+    @Test
+    @DisplayName("No Private Constructor With Injected Constructor Test")
+    fun noPrivateConstructorWithInjectedConstructorTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    private ASpongePlugin(Logger logger) {
+    }
+}
+""")
+    }
+}

--- a/src/test/kotlin/com/demonwav/mcdev/platform/sponge/SpongeInjectionInspectionTest.kt
+++ b/src/test/kotlin/com/demonwav/mcdev/platform/sponge/SpongeInjectionInspectionTest.kt
@@ -1,0 +1,317 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2019 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge
+
+import com.demonwav.mcdev.framework.EdtInterceptor
+import com.demonwav.mcdev.platform.sponge.inspection.SpongeInjectionInspection
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(EdtInterceptor::class)
+@DisplayName("Sponge Plugin Class Injection Inspection Tests")
+class SpongeInjectionInspectionTest : BaseSpongeTest() {
+
+    private fun doTest(@Language("JAVA") code: String, vararg resourceFiles: String) {
+        buildProject {
+            src {
+                java("test/ASpongePlugin.java", code)
+                resourceFiles.forEach { file(it, "", "", true) }
+            }
+        }
+
+        fixture.enableInspections(SpongeInjectionInspection::class.java)
+        fixture.checkHighlighting(false, false, false)
+    }
+
+    @Test
+    @DisplayName("Primitive Injection Test")
+    fun primitiveInjectionTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    private <error descr="Primitive types cannot be injected by Sponge.">int</error> number;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Field Uninjectable Type Type")
+    fun uninjectableFieldTypeTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    private <error descr="String cannot be injected by Sponge.">String</error> string;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Constructor Uninjectable Type Test")
+    fun constructorUninjectableTypeTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    private String string;
+
+    @Inject
+    private ASpongePlugin(<error descr="String cannot be injected by Sponge.">String</error> string) {
+        this.string = string;
+    }
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Constructor Optional Injection Test")
+    fun constructorOptionalInjectionTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    private Logger logger;
+
+    @Inject<error descr="Constructor injection cannot be optional.">(optional = true)</error>
+    private ASpongePlugin(Logger logger) {
+        this.logger = logger;
+    }
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Method Uninjectable Type Test")
+    fun methodUninjectableTypeTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    private String string;
+
+    @Inject
+    private void setString(<error descr="String cannot be injected by Sponge.">String</error> string) {
+        this.string = string;
+    }
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Injected Asset Without AssetId Test")
+    fun injectedAssetWithoutAssetIdTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.asset.Asset;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    private Asset <error descr="Injected Assets must be annotated with @AssetId.">asset</error>;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Absent Asset Test")
+    fun absentAssetTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.asset.Asset;
+import org.spongepowered.api.asset.AssetId;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    @AssetId(<error descr="Asset 'absent_asset' does not exist.">"absent_asset"</error>)
+    private Asset asset;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Asset Is A Directory Test")
+    fun assetIsADirectoryTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.asset.Asset;
+import org.spongepowered.api.asset.AssetId;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    @AssetId(<error descr="AssetId must point to a file.">"dir"</error>)
+    private Asset asset;
+}
+""", "assets/a-plugin/dir/an_asset.txt")
+    }
+
+    @Test
+    @DisplayName("Path Injection With @ConfigDir and @DefaultConfig Test")
+    fun pathInjectionWithConfigDirAndDefaultConfigTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.config.ConfigDir;
+import org.spongepowered.api.config.DefaultConfig;
+import org.spongepowered.api.plugin.Plugin;
+
+import java.io.File;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    @ConfigDir(sharedRoot = false)
+    @DefaultConfig(sharedRoot = false)
+    private File <error descr="@ConfigDir and @DefaultConfig cannot be used on the same field.">file</error>;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Path Injection Without @ConfigDir Test")
+    fun pathInjectionWithoutConfigDirTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.spongepowered.api.plugin.Plugin;
+
+import java.io.File;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    private File <error descr="An injected File must be annotated with either @ConfigDir or @DefaultConfig.">file</error>;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("Invalid @DefaultConfig Usage Test")
+    fun invalidDefaultConfigUsageTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.spongepowered.api.config.DefaultConfig;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    <error descr="Logger cannot be annotated with @DefaultConfig.">@DefaultConfig(sharedRoot = false)</error>
+    private Logger logger;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("@ConfigDir On ConfigurationLoader Test")
+    fun configDirOnConfigurationLoaderTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.spongepowered.api.config.ConfigDir;
+import org.spongepowered.api.config.DefaultConfig;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    @DefaultConfig(sharedRoot = false)
+    <error descr="Injected ConfigurationLoader cannot be annotated with @ConfigDir.">@ConfigDir(sharedRoot = false)</error>
+    private ConfigurationLoader<CommentedConfigurationNode> configurationLoader;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("ConfigurationLoader Not Annotated With @DefaultConfig Test")
+    fun configurationLoaderNotAnnotatedWithDefaultConfigTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.spongepowered.api.config.DefaultConfig;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    private ConfigurationLoader<CommentedConfigurationNode> <error descr="Injected ConfigurationLoader must be annotated with @DefaultConfig.">configurationLoader</error>;
+}
+""")
+    }
+
+    @Test
+    @DisplayName("ConfigurationLoader Generic Not CommentedConfigurationNode Test")
+    fun configurationLoaderGenericNotCommentedConfigurationNodeTest() {
+        doTest("""
+package test;
+
+import com.google.inject.Inject;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.spongepowered.api.config.DefaultConfig;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "a-plugin")
+public class ASpongePlugin {
+    @Inject
+    @DefaultConfig(sharedRoot = false)
+    private ConfigurationLoader<<error descr="Injected ConfigurationLoader generic parameter must be CommentedConfigurationNode.">ConfigurationNode</error>> configurationLoader;
+}
+""")
+    }
+}


### PR DESCRIPTION
This PR adds two inspections to plugin classes:
- a generic inspection that covers
  - invalid plugin IDs
  - missing or private no-arg constructor (except if another constructor is `@Inject`ed)

- an `@Inject` inspection for fields, constructors and setters args:
  - checks if only one constructor is injected
  - checks if injected constructors are not optional
  - checks if type is injectable.
    - The injectable types list is not exhaustive and not configurable, but I think it covers what people use. Please note I only tested injection inspection with SpongeVanilla, SpongeForge should work too. I haven't tested with Lantern.
  - is aware of `@ConfigDir` and `@DefaultConfig`. If the injected type is `File`, `Path` or `ConfigurationLoader<CommentedConfigurationNode>` it checks one of the two annotations is present.
  - handles `Asset` injection. It will check if `@AssetId` is present.
    - it also checks if the asset exists and is not a directory.

Member annotated with `@Inject` are marked as implicitly written for fields and used for ctors and setters. Injected fields with non-optional `@Inject` are also marked as not null.