### PR TITLE
Sponge Getter support fixes and improvements

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/completion/SpongeGetterFilterCompletionContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/completion/SpongeGetterFilterCompletionContributor.kt
@@ -13,29 +13,30 @@ package com.demonwav.mcdev.platform.sponge.completion
 import com.demonwav.mcdev.platform.sponge.inspection.SpongeInvalidGetterTargetInspection
 import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
 import com.demonwav.mcdev.platform.sponge.util.isValidSpongeListener
+import com.demonwav.mcdev.platform.sponge.util.resolveSpongeGetterTarget
 import com.demonwav.mcdev.util.findContainingMethod
-import com.demonwav.mcdev.util.packageName
+import com.demonwav.mcdev.util.withImportInsertion
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.JavaCompletionContributor
 import com.intellij.codeInsight.completion.JavaLookupElementBuilder
-import com.intellij.codeInsight.completion.SkipAutopopupInStrings
-import com.intellij.codeInsight.lookup.AutoCompletionPolicy
+import com.intellij.codeInsight.completion.PrioritizedLookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.lang.jvm.types.JvmReferenceType
 import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.JavaTokenType
 import com.intellij.psi.PsiAnnotation
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiNameValuePair
-import com.intellij.psi.PsiParameter
-import com.intellij.psi.PsiReferenceParameterList
-import com.intellij.psi.PsiSubstitutor
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiJavaToken
+import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypeElement
 import com.intellij.psi.search.ProjectScope
+import com.intellij.psi.util.PropertyUtil
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
+import org.jetbrains.plugins.groovy.lang.psi.util.childrenOfType
 
 class SpongeGetterFilterCompletionContributor : CompletionContributor() {
 
@@ -46,63 +47,91 @@ class SpongeGetterFilterCompletionContributor : CompletionContributor() {
         }
 
         val eventHandler = position.findContainingMethod() ?: return
-        if (!eventHandler.hasParameters()) {
-            return
-        }
-
         if (!eventHandler.isValidSpongeListener()) {
             return
         }
 
-        val annotation = position.parentOfType(PsiAnnotation::class)
-        if (annotation == null || annotation.qualifiedName?.equals(SpongeConstants.GETTER_ANNOTATION) == false) {
-            val param = position.parentOfType(PsiParameter::class)
-            if (
-                param != null &&
-                eventHandler.parameters.contains(param) &&
-                eventHandler.parameters[0] != param &&
-                PsiTreeUtil.nextLeaf(position) is PsiReferenceParameterList
-            ) {
-                val projectScope = ProjectScope.getAllScope(parameters.position.project)
-                val getterAnnoClass = JavaPsiFacade.getInstance(parameters.position.project)
-                    .findClass(SpongeConstants.GETTER_ANNOTATION, projectScope)
+        val prevVisibleLeaf = PsiTreeUtil.prevVisibleLeaf(position)
+        if (prevVisibleLeaf is PsiJavaToken && prevVisibleLeaf.tokenType == JavaTokenType.COMMA) {
+            // We are right after a comma
+            val projectScope = ProjectScope.getAllScope(parameters.position.project)
+            val getterAnnoClass = JavaPsiFacade.getInstance(parameters.position.project)
+                .findClass(SpongeConstants.GETTER_ANNOTATION, projectScope)
 
-                if (getterAnnoClass != null) {
-                    result.addElement(LookupElementBuilder.createWithIcon(getterAnnoClass)
-                            .appendTailText(" (${getterAnnoClass.packageName})", true)
-                            .withTypeText("EventFilter")
-                            .withInsertHandler { context, _ ->
-                                val at = context.document.text[context.startOffset - 1]
-                                if (at != '@') {
-                                    context.document.insertString(context.startOffset, "@")
-                                    context.commitDocument()
-                                }
+            if (getterAnnoClass != null) {
+                result.addElement(JavaLookupElementBuilder.forClass(getterAnnoClass, getterAnnoClass.name, true)
+                    .withTypeText("Event filter")
+                    .withInsertHandler { context, _ ->
+                        val at = context.document.text[context.startOffset - 1]
+                        if (at != '@') {
+                            context.document.insertString(context.startOffset, "@")
+                            context.commitDocument()
+                        }
 
-                                val inserted = context.file.findElementAt(context.startOffset)
-                                    ?.parentOfType(PsiAnnotation::class) ?: return@withInsertHandler
-                                SpongeInvalidGetterTargetInspection.QuickFix.doFix(getterAnnoClass.project, inserted)
-                            }
-                    )
+                        val inserted = context.file.findElementAt(context.startOffset)
+                            ?.parentOfType(PsiAnnotation::class) ?: return@withInsertHandler
+                        SpongeInvalidGetterTargetInspection.QuickFix.doFix(getterAnnoClass.project, inserted)
+                    }
+                )
+            }
+        } else if (prevVisibleLeaf is PsiJavaToken && prevVisibleLeaf.tokenType != JavaTokenType.AT) {
+            // We are not trying to complete an annotation
+            val modifierList = prevVisibleLeaf.parentOfType<PsiModifierList>()
+            val getterAnnotation = modifierList?.childrenOfType<PsiAnnotation>()
+                ?.firstOrNull { it.hasQualifiedName(SpongeConstants.GETTER_ANNOTATION) }
+            if (getterAnnotation != null) {
+                // We are right after a @Getter()
+                completeGetterParameterType(getterAnnotation, result)
+            }
+        }
+
+        val paramType = PsiTreeUtil.getPrevSiblingOfType(position, PsiTypeElement::class.java)
+        if (paramType != null) {
+            // We are completing the parameter name
+            val mods = PsiTreeUtil.getPrevSiblingOfType(paramType, PsiModifierList::class.java)
+            val getter = mods?.childrenOfType<PsiAnnotation>()
+                ?.firstOrNull { it.hasQualifiedName(SpongeConstants.GETTER_ANNOTATION) }
+            val getterTargetName = getter?.resolveSpongeGetterTarget()?.name
+            if (getterTargetName != null) {
+                val propertyName = PropertyUtil.getPropertyName(getterTargetName)
+                if (propertyName != null) {
+                    val element = LookupElementBuilder.create(propertyName)
+                    result.addElement(PrioritizedLookupElement.withPriority(element, 100.0))
                 }
             }
         }
+    }
 
-        if (!SkipAutopopupInStrings.isInStringLiteral(position)) {
-            return
+    private fun completeGetterParameterType(annotation: PsiAnnotation, result: CompletionResultSet) {
+        val getterTarget = annotation.resolveSpongeGetterTarget()
+        val classType = getterTarget?.returnType
+        if (classType != null) {
+            suggestGetterParameter(classType, result)
         }
 
-        val memberValue = position.parentOfType(PsiNameValuePair::class) ?: return
-        if (memberValue.attributeName != "value") {
-            return
-        }
-
-        val eventReferenceType = eventHandler.parameters[0].type as? JvmReferenceType ?: return
-        val eventClass = eventReferenceType.resolve() as? PsiClass ?: return
-        for (method in eventClass.allMethods) {
-            if (method.returnType != PsiType.VOID && method.containingClass?.qualifiedName != "java.lang.Object") {
-                result.addElement(JavaLookupElementBuilder.forMethod(method as PsiMethod, PsiSubstitutor.EMPTY)
-                        .withAutoCompletionPolicy(AutoCompletionPolicy.GIVE_CHANCE_TO_OVERWRITE))
+        val getterTargetClass = (getterTarget?.returnType as? PsiClassType)?.resolve()
+        if (getterTargetClass != null && getterTargetClass.qualifiedName == SpongeConstants.OPTIONAL) {
+            val paramRefType = getterTarget.returnTypeElement?.type as JvmReferenceType
+            val psiType = paramRefType.typeArguments().firstOrNull() as? PsiType
+            if (psiType != null) {
+                suggestGetterParameter(psiType, result)
             }
+        }
+    }
+
+    private fun suggestGetterParameter(psiType: PsiType, result: CompletionResultSet) {
+        if (psiType is PsiClassType) {
+            val resolveResult = psiType.resolveGenerics()
+            val resolvedClass = resolveResult.element ?: return
+            val genericTypes = resolveResult.substitutor.substitutionMap.values
+
+            val genericClasses = mutableListOf(resolvedClass)
+            genericTypes.mapNotNullTo(genericClasses) { (it as? PsiClassType)?.resolve() }
+
+            val element = JavaLookupElementBuilder.forClass(resolvedClass, psiType.presentableText, true)
+                .withTypeText("@Getter target type")
+                .withImportInsertion(genericClasses)
+            result.addElement(element)
         }
     }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/completion/SpongeGetterFilterCompletionContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/completion/SpongeGetterFilterCompletionContributor.kt
@@ -15,6 +15,7 @@ import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
 import com.demonwav.mcdev.platform.sponge.util.isValidSpongeListener
 import com.demonwav.mcdev.platform.sponge.util.resolveSpongeGetterTarget
 import com.demonwav.mcdev.util.findContainingMethod
+import com.demonwav.mcdev.util.isJavaOptional
 import com.demonwav.mcdev.util.withImportInsertion
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionParameters
@@ -110,7 +111,7 @@ class SpongeGetterFilterCompletionContributor : CompletionContributor() {
         }
 
         val getterTargetClass = (getterTarget?.returnType as? PsiClassType)?.resolve()
-        if (getterTargetClass != null && getterTargetClass.qualifiedName == SpongeConstants.OPTIONAL) {
+        if (getterTargetClass != null && getterTargetClass.isJavaOptional()) {
             val paramRefType = getterTarget.returnTypeElement?.type as JvmReferenceType
             val psiType = paramRefType.typeArguments().firstOrNull() as? PsiType
             if (psiType != null) {

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongeWrongGetterTypeInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongeWrongGetterTypeInspection.kt
@@ -64,8 +64,8 @@ class SpongeWrongGetterTypeInspection : BaseInspection() {
 
                         if (getterOptionalType != null && isOptional(parameterType)) {
                             val paramOptionalType = parameter.typeElement?.let(::getFirstGenericType)
-                            if (paramOptionalType != null
-                                && areInSameHierarchy(getterOptionalType, paramOptionalType)
+                            if (paramOptionalType != null &&
+                                areInSameHierarchy(getterOptionalType, paramOptionalType)
                             ) {
                                 continue
                             }
@@ -103,8 +103,9 @@ class SpongeWrongGetterTypeInspection : BaseInspection() {
 
         val newTypeElement = infos[1] as PsiTypeElement
         val newType = newTypeElement.type
-        if (newType is PsiPrimitiveType
-            || newType is PsiClassType && newType.hasParameters() && !newType.isJavaOptional()) {
+        if (newType is PsiPrimitiveType ||
+            newType is PsiClassType && newType.hasParameters() && !newType.isJavaOptional()
+        ) {
             return arrayOf(createFix(param, newTypeElement))
         }
 

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongeWrongGetterTypeInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/SpongeWrongGetterTypeInspection.kt
@@ -13,7 +13,7 @@ package com.demonwav.mcdev.platform.sponge.inspection
 import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
 import com.demonwav.mcdev.platform.sponge.util.isValidSpongeListener
 import com.demonwav.mcdev.platform.sponge.util.resolveSpongeGetterTarget
-import com.demonwav.mcdev.util.fullQualifiedName
+import com.demonwav.mcdev.util.isJavaOptional
 import com.intellij.lang.jvm.types.JvmReferenceType
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
@@ -87,7 +87,7 @@ class SpongeWrongGetterTypeInspection : BaseInspection() {
         }
 
         val typeClass = (type as? JvmReferenceType)?.resolve() as? PsiClass ?: return false
-        return typeClass.qualifiedName == SpongeConstants.OPTIONAL && typeClass.hasTypeParameters()
+        return typeClass.isJavaOptional() && typeClass.hasTypeParameters()
     }
 
     private fun getFirstGenericType(typeElement: PsiTypeElement): PsiType? {
@@ -103,7 +103,8 @@ class SpongeWrongGetterTypeInspection : BaseInspection() {
 
         val newTypeElement = infos[1] as PsiTypeElement
         val newType = newTypeElement.type
-        if (newType is PsiPrimitiveType || newType is PsiClassType && newType.hasParameters() && newType.fullQualifiedName != SpongeConstants.OPTIONAL) {
+        if (newType is PsiPrimitiveType
+            || newType is PsiClassType && newType.hasParameters() && !newType.isJavaOptional()) {
             return arrayOf(createFix(param, newTypeElement))
         }
 
@@ -111,7 +112,7 @@ class SpongeWrongGetterTypeInspection : BaseInspection() {
 
         val newTypeRef = newTypeElement.type as? JvmReferenceType
         val newClassType = (newTypeRef?.resolve() as? PsiClass)?.let {
-            if (it.qualifiedName == SpongeConstants.OPTIONAL && newTypeRef.typeArguments().count() > 0) {
+            if (it.isJavaOptional() && newTypeRef.typeArguments().count() > 0) {
                 val wrappedType = newTypeRef.typeArguments().first()
                 val resolveResult = (wrappedType as? PsiClassType)?.resolveGenerics() ?: return@let null
                 val element = resolveResult.element ?: return@let null

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/UseGetterReturnTypeInspectionGadgetsFix.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/UseGetterReturnTypeInspectionGadgetsFix.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiTypeElement
+import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.intellij.structuralsearch.plugin.util.SmartPsiPointer
 import com.siyeh.ig.InspectionGadgetsFix
 import com.siyeh.ig.psiutils.ImportUtils
@@ -35,7 +36,7 @@ class UseGetterReturnTypeInspectionGadgetsFix(
 
         val newTypeRef = newType.type as JvmReferenceType
         for (typeParam in newTypeRef.typeArguments()) {
-            val resolvedTypeParam = (typeParam as JvmReferenceType).resolve() as? PsiClass ?: return
+            val resolvedTypeParam = (typeParam as? PsiClassReferenceType)?.resolve() ?: continue
             ImportUtils.addImportIfNeeded(resolvedTypeParam, parameter)
         }
 

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/suppress/SpongeGetterParamOptionalInspectionSuppressor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/inspection/suppress/SpongeGetterParamOptionalInspectionSuppressor.kt
@@ -12,12 +12,9 @@ package com.demonwav.mcdev.platform.sponge.inspection.suppress
 
 import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
 import com.demonwav.mcdev.platform.sponge.util.isValidSpongeListener
-import com.demonwav.mcdev.platform.sponge.util.resolveSpongeGetterTarget
 import com.demonwav.mcdev.util.findContainingMethod
 import com.intellij.codeInspection.InspectionSuppressor
 import com.intellij.codeInspection.SuppressQuickFix
-import com.intellij.lang.jvm.types.JvmReferenceType
-import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiTypeElement
@@ -36,15 +33,7 @@ class SpongeGetterParamOptionalInspectionSuppressor : InspectionSuppressor {
             return false
         }
 
-        val getterAnnotation = param.getAnnotation(SpongeConstants.GETTER_ANNOTATION) ?: return false
-        val targetMethod = getterAnnotation.resolveSpongeGetterTarget() ?: return false
-
-        if (targetMethod.returnType != param.type) {
-            return false
-        }
-
-        val parameterType = (param.type as JvmReferenceType).resolve()
-        return parameterType != null && (parameterType as PsiClass).qualifiedName == SpongeConstants.OPTIONAL
+        return param.hasAnnotation(SpongeConstants.GETTER_ANNOTATION)
     }
 
     override fun getSuppressActions(element: PsiElement?, toolId: String): Array<out SuppressQuickFix> =

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
@@ -10,12 +10,23 @@
 
 package com.demonwav.mcdev.platform.sponge.reference
 
+import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
+import com.demonwav.mcdev.platform.sponge.util.isValidSpongeListener
 import com.demonwav.mcdev.util.findContainingMethod
 import com.demonwav.mcdev.util.reference.ReferenceResolver
+import com.intellij.codeInsight.completion.JavaLookupElementBuilder
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy
+import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.jvm.types.JvmReferenceType
+import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiNameValuePair
+import com.intellij.psi.PsiSubstitutor
+import com.intellij.psi.PsiType
+import com.intellij.psi.util.parentOfType
+import com.intellij.util.ArrayUtil
 
 object GetterEventListenerReferenceResolver : ReferenceResolver() {
 
@@ -27,12 +38,40 @@ object GetterEventListenerReferenceResolver : ReferenceResolver() {
 
         val eventType = method.parameters[0].type as? JvmReferenceType ?: return null
 
-        val methodName = (context as PsiLiteralExpression).value.toString()
+        val methodName = (context as? PsiLiteralExpression)?.value?.toString() ?: return null
         val methods = (eventType.resolve() as? PsiClass)?.findMethodsByName(methodName, true) ?: return null
         return methods.firstOrNull { !it.hasParameters() }
     }
 
     override fun collectVariants(context: PsiElement): Array<Any> {
-        return emptyArray()
+        val memberValue = context.parentOfType(PsiNameValuePair::class) ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+        if (memberValue.attributeName != "value") {
+            return ArrayUtil.EMPTY_OBJECT_ARRAY
+        }
+
+        val annotation = memberValue.parentOfType(PsiAnnotation::class)
+        if (annotation?.hasQualifiedName(SpongeConstants.GETTER_ANNOTATION) == false) {
+            return ArrayUtil.EMPTY_OBJECT_ARRAY
+        }
+
+        val eventHandler = context.findContainingMethod() ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+        if (!eventHandler.isValidSpongeListener()) {
+            return ArrayUtil.EMPTY_OBJECT_ARRAY
+        }
+
+        val eventReferenceType = eventHandler.parameters[0].type as? JvmReferenceType
+            ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+        val eventClass = eventReferenceType.resolve() as? PsiClass ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+        val methods = mutableListOf<LookupElement>()
+        for (method in eventClass.allMethods) {
+            if (method.returnType != PsiType.VOID && !method.hasParameters()
+                && method.containingClass?.qualifiedName != "java.lang.Object"
+            ) {
+                methods += JavaLookupElementBuilder.forMethod(method, PsiSubstitutor.EMPTY)
+                    .withAutoCompletionPolicy(AutoCompletionPolicy.GIVE_CHANCE_TO_OVERWRITE)
+            }
+        }
+
+        return methods.toTypedArray()
     }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
@@ -66,8 +66,8 @@ object GetterEventListenerReferenceResolver : ReferenceResolver() {
         val eventClass = eventReferenceType.resolve() as? PsiClass ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
         val methods = mutableListOf<LookupElement>()
         for (method in eventClass.allMethods) {
-            if (method.returnType != PsiType.VOID && method.hasModifier(JvmModifier.PUBLIC) && !method.hasParameters()
-                && method.containingClass?.qualifiedName != CommonClassNames.JAVA_LANG_OBJECT
+            if (method.returnType != PsiType.VOID && method.hasModifier(JvmModifier.PUBLIC) &&
+                !method.hasParameters() && method.containingClass?.qualifiedName != CommonClassNames.JAVA_LANG_OBJECT
             ) {
                 methods += JavaLookupElementBuilder.forMethod(method, PsiSubstitutor.EMPTY)
                     .withAutoCompletionPolicy(AutoCompletionPolicy.GIVE_CHANCE_TO_OVERWRITE)

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
@@ -17,6 +17,7 @@ import com.demonwav.mcdev.util.reference.ReferenceResolver
 import com.intellij.codeInsight.completion.JavaLookupElementBuilder
 import com.intellij.codeInsight.lookup.AutoCompletionPolicy
 import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.lang.jvm.JvmModifier
 import com.intellij.lang.jvm.types.JvmReferenceType
 import com.intellij.psi.CommonClassNames
 import com.intellij.psi.PsiAnnotation
@@ -65,7 +66,7 @@ object GetterEventListenerReferenceResolver : ReferenceResolver() {
         val eventClass = eventReferenceType.resolve() as? PsiClass ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
         val methods = mutableListOf<LookupElement>()
         for (method in eventClass.allMethods) {
-            if (method.returnType != PsiType.VOID && !method.hasParameters()
+            if (method.returnType != PsiType.VOID && method.hasModifier(JvmModifier.PUBLIC) && !method.hasParameters()
                 && method.containingClass?.qualifiedName != CommonClassNames.JAVA_LANG_OBJECT
             ) {
                 methods += JavaLookupElementBuilder.forMethod(method, PsiSubstitutor.EMPTY)

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/reference/GetterEventListenerReferenceResolver.kt
@@ -18,6 +18,7 @@ import com.intellij.codeInsight.completion.JavaLookupElementBuilder
 import com.intellij.codeInsight.lookup.AutoCompletionPolicy
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.jvm.types.JvmReferenceType
+import com.intellij.psi.CommonClassNames
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
@@ -65,7 +66,7 @@ object GetterEventListenerReferenceResolver : ReferenceResolver() {
         val methods = mutableListOf<LookupElement>()
         for (method in eventClass.allMethods) {
             if (method.returnType != PsiType.VOID && !method.hasParameters()
-                && method.containingClass?.qualifiedName != "java.lang.Object"
+                && method.containingClass?.qualifiedName != CommonClassNames.JAVA_LANG_OBJECT
             ) {
                 methods += JavaLookupElementBuilder.forMethod(method, PsiSubstitutor.EMPTY)
                     .withAutoCompletionPolicy(AutoCompletionPolicy.GIVE_CHANCE_TO_OVERWRITE)

--- a/src/main/kotlin/com/demonwav/mcdev/platform/sponge/util/SpongeConstants.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/sponge/util/SpongeConstants.kt
@@ -21,5 +21,4 @@ object SpongeConstants {
     const val IS_CANCELLED_ANNOTATION = "org.spongepowered.api.event.filter.IsCancelled"
     const val CANCELLABLE = "org.spongepowered.api.event.Cancellable"
     const val EVENT_ISCANCELLED_METHOD_NAME = "isCancelled"
-    const val OPTIONAL = "java.util.Optional"
 }

--- a/src/main/kotlin/com/demonwav/mcdev/util/class-utils.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/class-utils.kt
@@ -12,6 +12,7 @@ package com.demonwav.mcdev.util
 
 import com.intellij.navigation.AnonymousElementProvider
 import com.intellij.openapi.project.Project
+import com.intellij.psi.CommonClassNames
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
@@ -278,6 +279,10 @@ private fun areReallyOnlyParametersErasureEqual(
 
     return true
 }
+
+fun PsiClass.isJavaOptional(): Boolean = this.qualifiedName == CommonClassNames.JAVA_UTIL_OPTIONAL
+
+fun PsiClassType.isJavaOptional(): Boolean = this.fullQualifiedName == CommonClassNames.JAVA_UTIL_OPTIONAL
 
 class ClassNameResolutionFailedException : Exception {
     constructor() : super()

--- a/src/main/kotlin/com/demonwav/mcdev/util/psi-utils.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/psi-utils.kt
@@ -10,6 +10,7 @@
 
 package com.demonwav.mcdev.util
 
+import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.psi.ElementManipulator
@@ -35,6 +36,7 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.TypeConversionUtil
 import com.intellij.refactoring.changeSignature.ChangeSignatureUtil
+import com.siyeh.ig.psiutils.ImportUtils
 import org.jetbrains.annotations.Contract
 import java.util.stream.Stream
 
@@ -197,3 +199,8 @@ val <T : PsiElement> T.manipulator: ElementManipulator<T>?
 inline fun <T> PsiElement.cached(crossinline compute: () -> T): T {
     return CachedValuesManager.getCachedValue(this) { CachedValueProvider.Result.create(compute(), this) }
 }
+
+fun LookupElementBuilder.withImportInsertion(toImport: List<PsiClass>): LookupElementBuilder =
+    this.withInsertHandler { insertionContext, _ ->
+        toImport.forEach { ImportUtils.addImportIfNeeded(it, insertionContext.file) }
+    }


### PR DESCRIPTION
PR #488 added Getter filters support, but it turns out I did not tested it properly and missed many cases in which a parameter type can or cannot be used. Custom completion was not really good too.

Those issues are addressed in this PR, in addition to other tweaks and a cleanup of my old code.

_I made a better description in my first commit so please read it_