### PR TITLE
Fix generated authors value for mods.toml

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeProjectConfiguration.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/forge/ForgeProjectConfiguration.kt
@@ -90,7 +90,11 @@ open class ForgeProjectConfiguration : ProjectConfiguration() {
             meta.findOrCreateChildData(this, ForgeConstants.MODS_TOML)
         }
 
-        val authorsText = baseConfigs.authors.joinToString(", ") { "\"$it\"" }
+        val authorsText = if (mcVer < ForgeModuleType.FG3_VERSION) {
+            baseConfigs.authors.joinToString(", ") { "\"$it\"" }
+        } else {
+            baseConfigs.authors.joinToString(",")
+        }
 
         ForgeTemplate.applyModDescriptorTemplate(
             project,


### PR DESCRIPTION
The plugin was always generating a JSON array content, regardless of the format.

Fixes #666 
Supersedes #670 that does not completely fix the issue.