### PR TITLE
Fix mouse ungrabbing for recent game versions

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/debug/McpRunConfigurationExtension.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/debug/McpRunConfigurationExtension.kt
@@ -19,24 +19,31 @@ import com.intellij.debugger.engine.DebugProcessImpl
 import com.intellij.debugger.engine.DebugProcessListener
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModulePointer
+import com.intellij.openapi.module.ModulePointerManager
 
-class McpRunConfigurationExtension : ModuleDebugRunConfigurationExtension(), DebugProcessListener {
+class McpRunConfigurationExtension : ModuleDebugRunConfigurationExtension() {
 
     override fun attachToProcess(handler: ProcessHandler, module: Module) {
         if (MinecraftFacet.getInstance(module)?.isOfType(McpModuleType) == true) {
-            DebuggerManager.getInstance(module.project).addDebugProcessListener(handler, this)
+            val modulePointer = ModulePointerManager.getInstance(module.project).create(module)
+            DebuggerManager.getInstance(module.project)
+                .addDebugProcessListener(handler, MyProcessListener(modulePointer))
         }
     }
 
-    override fun processAttached(process: DebugProcess) {
-        if (process !is DebugProcessImpl) {
-            return
+    private inner class MyProcessListener(private val modulePointer: ModulePointer) : DebugProcessListener {
+
+        override fun processAttached(process: DebugProcess) {
+            if (process !is DebugProcessImpl) {
+                return
+            }
+
+            // Add session listener
+            process.xdebugProcess?.session?.addSessionListener(UngrabMouseDebugSessionListener(process, modulePointer))
+
+            // We don't need any further events
+            process.removeDebugProcessListener(this)
         }
-
-        // Add session listener
-        process.xdebugProcess?.session?.addSessionListener(UngrabMouseDebugSessionListener(process))
-
-        // We don't need any further events
-        process.removeDebugProcessListener(this)
     }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/debug/UngrabMouseDebugSessionListener.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/debug/UngrabMouseDebugSessionListener.kt
@@ -16,10 +16,11 @@ import com.intellij.debugger.jdi.VirtualMachineProxyImpl
 import com.intellij.xdebugger.XDebugSessionListener
 import com.sun.jdi.BooleanValue
 import com.sun.jdi.ClassType
+import com.sun.jdi.ObjectReference
 
 class UngrabMouseDebugSessionListener(private val process: DebugProcessImpl) : XDebugSessionListener {
 
-    private fun grabMouse(grab: Boolean) {
+    private fun ungrabMouse() {
         val suspendContextImpl = process.debuggerContext.suspendContext ?: return
         if (suspendContextImpl.thread?.isAtBreakpoint != true) {
             return
@@ -30,18 +31,58 @@ class UngrabMouseDebugSessionListener(private val process: DebugProcessImpl) : X
         val virtualMachine = debugProcess.virtualMachineProxy as? VirtualMachineProxyImpl ?: return
         val evaluationContext = EvaluationContextImpl(suspendContextImpl, frameProxy)
 
-        val mouseClass = virtualMachine.classesByName("org.lwjgl.input.Mouse")?.singleOrNull() as? ClassType ?: return
+        val mouseClass = virtualMachine.classesByName("org.lwjgl.input.Mouse")?.singleOrNull() as? ClassType
+        // LWJGL 3 does not have the Mouse class, Minecraft uses its own MouseHelper instead
+        if (mouseClass != null) {
+            ungrab2(mouseClass, virtualMachine, debugProcess, evaluationContext)
+        } else {
+            ungrab3(virtualMachine, debugProcess, evaluationContext)
+        }
+    }
+
+    private fun ungrab2(
+        mouseClass: ClassType,
+        virtualMachine: VirtualMachineProxyImpl,
+        debugProcess: DebugProcessImpl,
+        evaluationContext: EvaluationContextImpl
+    ) {
         val isGrabbed = mouseClass.methodsByName("isGrabbed", "()Z")?.singleOrNull() ?: return
         val setGrabbed = mouseClass.methodsByName("setGrabbed", "(Z)V")?.singleOrNull() ?: return
-        val grabValue = virtualMachine.mirrorOf(grab)
+        val grabValue = virtualMachine.mirrorOf(false)
 
         val currentState = debugProcess.invokeMethod(evaluationContext, mouseClass, isGrabbed, emptyList())
-        if ((currentState as? BooleanValue)?.value() != grab) {
+        if ((currentState as? BooleanValue)?.value() == true) {
             debugProcess.invokeMethod(evaluationContext, mouseClass, setGrabbed, listOf(grabValue))
         }
     }
 
+    private fun ungrab3(
+        virtualMachine: VirtualMachineProxyImpl,
+        debugProcess: DebugProcessImpl,
+        evaluationContext: EvaluationContextImpl
+    ) {
+        val minecraftClass =
+            virtualMachine.classesByName("net.minecraft.client.Minecraft")?.singleOrNull() as? ClassType ?: return
+        val minecraftGetter =
+            minecraftClass.methodsByName("getInstance", "()Lnet/minecraft/client/Minecraft;")?.singleOrNull() ?: return
+        val minecraft = debugProcess.invokeMethod(
+            evaluationContext,
+            minecraftClass,
+            minecraftGetter,
+            emptyList()
+        ) as? ObjectReference ?: return
+
+        val mouseHelperField = minecraftClass.fieldByName("mouseHelper") ?: return
+        val mouseHelper = minecraft.getValue(mouseHelperField) as? ObjectReference ?: return
+
+        val mouseHelperClass =
+            virtualMachine.classesByName("net.minecraft.client.MouseHelper")?.singleOrNull() as? ClassType ?: return
+        val grabMouse = mouseHelperClass.methodsByName("ungrabMouse", "()V")?.singleOrNull() ?: return
+
+        debugProcess.invokeMethod(evaluationContext, mouseHelper, grabMouse, emptyList())
+    }
+
     override fun sessionPaused() {
-        grabMouse(false)
+        ungrabMouse()
     }
 }


### PR DESCRIPTION
Fixes #686 

IntelliJ should take the focus anyway when breakpoints are hit (this is configurable), but it seems it does not always work.

Note that my changes ungrab the mouse correctly, but the cursor is still hidden (at least for me, on Windows 10). The method used should handle that but it doesn't work for some reason.