### PR TITLE
Improve mixin config detection

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileType.kt
@@ -13,8 +13,19 @@ package com.demonwav.mcdev.platform.mixin.config
 import com.demonwav.mcdev.asset.PlatformAssets
 import com.intellij.json.JsonLanguage
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.fileTypes.ex.FileTypeIdentifiableByVirtualFile
+import com.intellij.openapi.vfs.VirtualFile
 
-object MixinConfigFileType : LanguageFileType(JsonLanguage.INSTANCE) {
+object MixinConfigFileType : LanguageFileType(JsonLanguage.INSTANCE), FileTypeIdentifiableByVirtualFile {
+
+    private val filenameRegex = "(^|\\.)mixins?\\.".toRegex()
+
+    // Dynamic file type detection is sadly needed as we're overriding the built-in json file type.
+    // Simply using an extension pattern is not sufficient as there is no way to bump the version to tell
+    // the cache that the pattern has changed, as it now has, without changing the file type name.
+    // See https://www.plugin-dev.com/intellij/custom-language/file-type-detection/#guidelines
+    override fun isMyFileType(file: VirtualFile) = file.name.contains(filenameRegex)
+
     override fun getName() = "Mixin Configuration"
     override fun getDescription() = "Mixin Configuration"
     override fun getDefaultExtension() = ""

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileType.kt
@@ -18,7 +18,7 @@ import com.intellij.openapi.vfs.VirtualFile
 
 object MixinConfigFileType : LanguageFileType(JsonLanguage.INSTANCE), FileTypeIdentifiableByVirtualFile {
 
-    private val filenameRegex = "(^|\\.)mixins?\\.".toRegex()
+    private val filenameRegex = "(^|\\.)mixins?(\\.[^.]+)*\\.json\$".toRegex()
 
     // Dynamic file type detection is sadly needed as we're overriding the built-in json file type.
     // Simply using an extension pattern is not sufficient as there is no way to bump the version to tell

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -253,7 +253,7 @@
                                order="before javaSkipAutopopupInStrings"/>
 
         <!-- Mixin configuration -->
-        <fileType name="Mixin Configuration" language="JSON" implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType" fieldName="INSTANCE" patterns="mixins.*.json" />
+        <fileType name="Mixin Configuration" language="JSON" implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType" fieldName="INSTANCE" />
         <psi.referenceContributor language="JSON" implementation="com.demonwav.mcdev.platform.mixin.config.reference.MixinConfigReferenceContributor" />
         <lang.importOptimizer language="JSON" implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigImportOptimizer"/>
 


### PR DESCRIPTION
Many people in the Fabric community use the convention of `modid.mixins.json` rather than `mixins.modid.json`. After some discussion on the jetbrains slack, we concluded that this was the best solution.