### PR TITLE
Unused mixin inspection

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/MixinModule.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/MixinModule.kt
@@ -13,6 +13,17 @@ package com.demonwav.mcdev.platform.mixin
 import com.demonwav.mcdev.facet.MinecraftFacet
 import com.demonwav.mcdev.platform.AbstractModule
 import com.demonwav.mcdev.platform.PlatformType
+import com.demonwav.mcdev.platform.mixin.config.MixinConfig
+import com.intellij.json.psi.JsonFile
+import com.intellij.json.psi.JsonObject
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.fileTypes.FileTypes
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FileTypeIndex
+import com.intellij.psi.search.GlobalSearchScope
 import javax.swing.Icon
 
 class MixinModule(facet: MinecraftFacet) : AbstractModule(facet) {
@@ -20,4 +31,30 @@ class MixinModule(facet: MinecraftFacet) : AbstractModule(facet) {
     override val moduleType = MixinModuleType
     override val type = PlatformType.MIXIN
     override val icon: Icon? = null
+
+    companion object {
+        private val mixinFileType = lazy { FileTypeManager.getInstance().findFileTypeByName("Mixin Configuration") ?: FileTypes.UNKNOWN }
+
+        fun getMixinConfigs(project: Project, scope: GlobalSearchScope): Collection<MixinConfig> {
+            return FileTypeIndex.getFiles(mixinFileType.value, scope).
+                    mapNotNull { (PsiManager.getInstance(project).findFile(it) as? JsonFile)?.topLevelValue as? JsonObject }.
+                    map { MixinConfig(project, it) }
+        }
+
+        fun getAllMixins(project: Project, scope: GlobalSearchScope): Collection<PsiClass> {
+            return getMixinConfigs(project, scope).asSequence().
+                    flatMap { (it.qualifiedMixins + it.qualifiedClient + it.qualifiedServer).asSequence() }.
+                    filterNotNull().
+                    distinct().
+                    flatMap { JavaPsiFacade.getInstance(project).findClasses(it, scope).asSequence() }.
+                    toList()
+        }
+
+        fun getBestWritableConfigForMixinClass(project: Project, scope: GlobalSearchScope, mixinClassName: String): MixinConfig? {
+            return getMixinConfigs(project, scope).
+                    filter { it.isWritable && mixinClassName.startsWith("${it.pkg}.") }.
+                    maxBy { it.pkg?.length ?: 0 }
+        }
+    }
+
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfig.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfig.kt
@@ -1,0 +1,231 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2020 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config
+
+import com.intellij.json.JsonElementTypes
+import com.intellij.json.psi.*
+import com.intellij.lang.LanguageImportStatements
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.*
+import com.intellij.psi.codeStyle.CodeStyleManager
+
+class MixinConfig(private val project: Project, private var json: JsonObject) {
+
+    private val generator = JsonElementGenerator(project)
+    var autoReformat = true
+
+    val isWritable: Boolean
+        get() = json.isWritable
+
+    val file: VirtualFile?
+        get() = json.containingFile.virtualFile
+
+    var pkg: String?
+        get() = (json.findProperty("package")?.value as? JsonStringLiteral)?.value
+        set(value) {
+            if (value == null) {
+                val prop = json.findProperty("package") ?: return
+                deleteCommaAround(prop)
+                prop.delete()
+            } else {
+                val prop = json.findProperty("package")
+                if (prop == null) {
+                    JsonPsiUtil.addProperty(json, generator.createProperty("package", generator.createStringLiteral(value).text), false)
+                } else {
+                    prop.value?.replace(generator.createStringLiteral(value))
+                }
+            }
+            if (autoReformat)
+                reformat()
+        }
+
+    var mixins: MutableList<String?>
+        get() = MixinList("mixins")
+        set(value) {
+            val prevAutoReformat = autoReformat
+            autoReformat = false
+            val v = mixins
+            v.clear()
+            v.addAll(value)
+            autoReformat = prevAutoReformat
+            if (autoReformat)
+                reformat()
+        }
+
+    var client: MutableList<String?>
+        get() = MixinList("client")
+        set(value) {
+            val prevAutoReformat = autoReformat
+            autoReformat = false
+            val v = client
+            v.clear()
+            v.addAll(value)
+            autoReformat = prevAutoReformat
+            if (autoReformat)
+                reformat()
+        }
+
+    var server: MutableList<String?>
+        get() = MixinList("server")
+        set(value) {
+            val prevAutoReformat = autoReformat
+            autoReformat = false
+            val v = server
+            v.clear()
+            v.addAll(value)
+            autoReformat = prevAutoReformat
+            if (autoReformat)
+                reformat()
+        }
+
+    val qualifiedMixins: MutableList<String?>
+        get() = FullyQualifiedMixinList(MixinList("mixins"))
+    val qualifiedClient: MutableList<String?>
+        get() = FullyQualifiedMixinList(MixinList("client"))
+    val qualifiedServer: MutableList<String?>
+        get() = FullyQualifiedMixinList(MixinList("server"))
+
+    private fun deleteCommaAround(element: PsiElement) {
+        // Delete the comma before, if it exists
+        var elem = element.prevSibling
+        while (elem != null) {
+            if (elem.node.elementType === JsonElementTypes.COMMA || (elem is PsiErrorElement && elem.text == ",")) {
+                elem.delete()
+                return
+            } else if (elem is PsiComment || elem is PsiWhiteSpace) {
+                elem = elem.prevSibling
+            } else {
+                break
+            }
+        }
+
+        // If it didn't exist, delete the comma after if it exists
+        elem = element.nextSibling
+        while (elem != null) {
+            if (elem.node.elementType === JsonElementTypes.COMMA || (elem is PsiErrorElement && elem.text == ",")) {
+                elem.delete()
+                return
+            } else if (elem is PsiComment || elem is PsiWhiteSpace) {
+                elem = elem.nextSibling
+            } else {
+                break
+            }
+        }
+    }
+
+    private fun reformat() {
+        json = CodeStyleManager.getInstance(project).reformat(json) as JsonObject
+        file?.let { file ->
+            val psiFile = PsiManager.getInstance(project).findFile(file) as? JsonFile ?: return
+            LanguageImportStatements.INSTANCE.forFile(psiFile).forEach { it.processFile(psiFile).run() }
+            json = (PsiManager.getInstance(project).findFile(file) as JsonFile).topLevelValue as JsonObject
+        }
+    }
+
+    private inner class FullyQualifiedMixinList(private val delegate: MixinList) : AbstractMutableList<String?>() {
+        override val size: Int
+            get() = delegate.size
+
+        override fun add(index: Int, element: String?) = delegate.add(index, removePackage(element))
+
+        override fun get(index: Int) = prependPackage(delegate[index])
+
+        override fun removeAt(index: Int) = prependPackage(delegate.removeAt(index))
+
+        override fun set(index: Int, element: String?) = prependPackage(delegate.set(index, removePackage(element)))
+
+        private fun removePackage(element: String?): String? {
+            val p = pkg ?: return null
+            if (element?.startsWith("$p.") == false) return null
+            return element?.substring(p.length + 1)
+        }
+
+        private fun prependPackage(result: String?) = result?.let { "$pkg.$result" }
+
+    }
+
+    private inner class MixinList(private val key: String) : AbstractMutableList<String?>() {
+
+        private val array: List<JsonValue>?
+            get() = (json.findProperty(key)?.value as? JsonArray)?.valueList
+
+        override val size: Int
+            get() = array?.size ?: 0
+
+        override fun add(index: Int, element: String?) {
+            val oldSize = size
+            if (index < 0 || index > oldSize)
+                throw IndexOutOfBoundsException(index.toString())
+            val arr = getOrCreateJsonArray()
+            val newValue = if (element == null) generator.createValue("null") else generator.createStringLiteral(element)
+            when {
+                oldSize == 0 -> {
+                    // No comma added
+                    arr.addAfter(newValue, arr.firstChild)
+                }
+                index == oldSize -> {
+                    // Add comma before
+                    val anchor = arr.lastChild
+                    arr.addBefore(generator.createComma(), anchor)
+                    arr.addBefore(newValue, anchor)
+                }
+                else -> {
+                    // Add comma after
+                    val anchor = arr.valueList[index]
+                    arr.addBefore(newValue, anchor)
+                    arr.addBefore(generator.createComma(), anchor)
+                }
+            }
+            if (autoReformat)
+                reformat()
+        }
+
+        override fun get(index: Int): String? {
+            if (index < 0 || index >= size)
+                throw IndexOutOfBoundsException(index.toString())
+            return (array?.get(index) as? JsonStringLiteral)?.value
+        }
+
+        override fun removeAt(index: Int): String? {
+            if (index < 0 || index >= size)
+                throw IndexOutOfBoundsException(index.toString())
+            val toDelete = array?.get(index) ?: return null
+            val oldStr = (toDelete as? JsonStringLiteral)?.value
+            deleteCommaAround(toDelete)
+            toDelete.delete()
+            if (autoReformat)
+                reformat()
+            return oldStr
+        }
+
+        override fun set(index: Int, element: String?): String? {
+            if (index < 0 || index >= size)
+                throw IndexOutOfBoundsException(index.toString())
+            val toReplace = array?.get(index) ?: return null
+            val oldStr = (toReplace as? JsonStringLiteral)?.value
+            toReplace.replace(if (element == null) generator.createValue("null") else generator.createStringLiteral(element))
+            if (autoReformat)
+                reformat()
+            return oldStr
+        }
+
+        private fun getOrCreateJsonArray(): JsonArray {
+            val existingArray = json.findProperty(key)?.value as? JsonArray
+            if (existingArray != null)
+                return existingArray
+            val added = JsonPsiUtil.addProperty(json, generator.createProperty(key, "[]"), false)
+            return (added as JsonProperty).value as JsonArray
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinClass.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinClass.kt
@@ -23,7 +23,7 @@ import com.intellij.psi.search.searches.AnnotatedElementsSearch
 
 object MixinClass : ClassNameReferenceProvider() {
 
-    override fun getBasePackage(element: PsiElement): String? {
+    public override fun getBasePackage(element: PsiElement): String? {
         // Literal -> Array -> Property -> Object
         val obj = element.parent?.parent?.parent as? JsonObject ?: return null
         return (obj.findProperty("package")?.value as? JsonStringLiteral)?.value

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinClass.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinClass.kt
@@ -23,7 +23,7 @@ import com.intellij.psi.search.searches.AnnotatedElementsSearch
 
 object MixinClass : ClassNameReferenceProvider() {
 
-    public override fun getBasePackage(element: PsiElement): String? {
+    override fun getBasePackage(element: PsiElement): String? {
         // Literal -> Array -> Property -> Object
         val obj = element.parent?.parent?.parent as? JsonObject ?: return null
         return (obj.findProperty("package")?.value as? JsonStringLiteral)?.value

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/UnusedMixinInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/UnusedMixinInspection.kt
@@ -1,0 +1,84 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2020 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection
+
+import com.demonwav.mcdev.inspection.sideonly.Side
+import com.demonwav.mcdev.inspection.sideonly.SideOnlyUtil
+import com.demonwav.mcdev.platform.mixin.config.MixinConfig
+import com.demonwav.mcdev.platform.mixin.MixinModule
+import com.demonwav.mcdev.platform.mixin.util.isMixin
+import com.demonwav.mcdev.util.findModule
+import com.demonwav.mcdev.util.fullQualifiedName
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.json.psi.*
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.GlobalSearchScope
+
+class UnusedMixinInspection : MixinInspection() {
+
+    override fun getStaticDescription() = "Ensures that all mixin classes are referenced from a mixin configuration"
+
+    override fun buildVisitor(holder: ProblemsHolder) = Visitor(holder)
+
+    class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+        override fun visitClass(clazz: PsiClass?) {
+            val module = clazz?.findModule() ?: return
+            if (clazz.isMixin) {
+                for (config in MixinModule.getMixinConfigs(module.project, GlobalSearchScope.moduleScope(module))) {
+                    if (config.qualifiedMixins.any { it == clazz.fullQualifiedName })
+                        return
+                    if (config.qualifiedClient.any { it == clazz.fullQualifiedName })
+                        return
+                    if (config.qualifiedServer.any { it == clazz.fullQualifiedName })
+                        return
+                }
+
+                val bestQuickFixConfig = MixinModule.getBestWritableConfigForMixinClass(module.project, GlobalSearchScope.moduleScope(module), clazz.fullQualifiedName ?: "")
+                val problematicElement = clazz.nameIdentifier
+                if (problematicElement != null) {
+                    val bestQuickFixFile = bestQuickFixConfig?.file
+                    val qualifiedName = clazz.fullQualifiedName
+                    if (bestQuickFixFile != null && qualifiedName != null) {
+                        val quickFix = QuickFix(bestQuickFixFile, qualifiedName, SideOnlyUtil.getSideForClass(clazz))
+                        holder.registerProblem(problematicElement, "Mixin not found in any mixin config", quickFix)
+                    } else {
+                        holder.registerProblem(problematicElement, "Mixin not found in any mixin config")
+                    }
+                }
+            }
+        }
+    }
+
+    private class QuickFix(private val quickFixFile: VirtualFile, private val qualifiedName: String, private val side: Side) : LocalQuickFix {
+        override fun getName() = "Add to mixin config"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val psiFile = PsiManager.getInstance(project).findFile(quickFixFile) as? JsonFile ?: return
+            val root = psiFile.topLevelValue as? JsonObject ?: return
+            val config = MixinConfig(project, root)
+            val mixinList = when (side) {
+                Side.CLIENT -> config.qualifiedClient
+                Side.SERVER -> config.qualifiedServer
+                else -> config.qualifiedMixins
+            }
+            mixinList.add(qualifiedName)
+        }
+
+        override fun getFamilyName() = name
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/UnusedMixinInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/UnusedMixinInspection.kt
@@ -10,17 +10,18 @@
 
 package com.demonwav.mcdev.platform.mixin.inspection
 
-import com.demonwav.mcdev.inspection.sideonly.Side
-import com.demonwav.mcdev.inspection.sideonly.SideOnlyUtil
-import com.demonwav.mcdev.platform.mixin.config.MixinConfig
+import com.demonwav.mcdev.platform.forge.inspections.sideonly.Side
+import com.demonwav.mcdev.platform.forge.inspections.sideonly.SideOnlyUtil
 import com.demonwav.mcdev.platform.mixin.MixinModule
+import com.demonwav.mcdev.platform.mixin.config.MixinConfig
 import com.demonwav.mcdev.platform.mixin.util.isMixin
 import com.demonwav.mcdev.util.findModule
 import com.demonwav.mcdev.util.fullQualifiedName
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.json.psi.*
+import com.intellij.json.psi.JsonFile
+import com.intellij.json.psi.JsonObject
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.JavaElementVisitor
@@ -47,7 +48,11 @@ class UnusedMixinInspection : MixinInspection() {
                         return
                 }
 
-                val bestQuickFixConfig = MixinModule.getBestWritableConfigForMixinClass(module.project, GlobalSearchScope.moduleScope(module), clazz.fullQualifiedName ?: "")
+                val bestQuickFixConfig = MixinModule.getBestWritableConfigForMixinClass(
+                    module.project,
+                    GlobalSearchScope.moduleScope(module),
+                    clazz.fullQualifiedName ?: ""
+                )
                 val problematicElement = clazz.nameIdentifier
                 if (problematicElement != null) {
                     val bestQuickFixFile = bestQuickFixConfig?.file
@@ -63,7 +68,11 @@ class UnusedMixinInspection : MixinInspection() {
         }
     }
 
-    private class QuickFix(private val quickFixFile: VirtualFile, private val qualifiedName: String, private val side: Side) : LocalQuickFix {
+    private class QuickFix(
+        private val quickFixFile: VirtualFile,
+        private val qualifiedName: String,
+        private val side: Side
+    ) : LocalQuickFix {
         override fun getName() = "Add to mixin config"
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
@@ -80,5 +89,4 @@ class UnusedMixinInspection : MixinInspection() {
 
         override fun getFamilyName() = name
     }
-
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -450,6 +450,14 @@
         <!--endregion-->
 
         <!--region MIXIN INSPECTIONS-->
+        <localInspection displayName="Mixin not in a mixin config"
+                          shortName="UnusedMixin"
+                          groupName="Mixin"
+                          language="JAVA"
+                          enabledByDefault="true"
+                          level="WARNING"
+                          hasStaticDescription="true"
+                          implementationClass="com.demonwav.mcdev.platform.mixin.inspection.UnusedMixinInspection"/>
         <localInspection displayName="Mixin annotation outside of @Mixin class"
                          shortName="AnnotationOutsideOfMixin"
                          groupName="Mixin"


### PR DESCRIPTION
This adds an inspection which highlights when a mixin is not in any mixin config file, and includes a quick fix to add the mixin to the mixin config with the longest matching package name.

The `MixinConfig` class looks a bit excessive, but it's also used by some other features in my fork, which will come in later PRs.