### PR TITLE
Fix mixin config value inspection for boxed types

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigValueInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigValueInspection.kt
@@ -15,11 +15,20 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.json.psi.JsonArray
 import com.intellij.json.psi.JsonBooleanLiteral
 import com.intellij.json.psi.JsonElementVisitor
+import com.intellij.json.psi.JsonNullLiteral
 import com.intellij.json.psi.JsonNumberLiteral
 import com.intellij.json.psi.JsonObject
 import com.intellij.json.psi.JsonProperty
 import com.intellij.json.psi.JsonStringLiteral
 import com.intellij.json.psi.JsonValue
+import com.intellij.psi.CommonClassNames
+import com.intellij.psi.CommonClassNames.JAVA_LANG_BYTE
+import com.intellij.psi.CommonClassNames.JAVA_LANG_CHARACTER
+import com.intellij.psi.CommonClassNames.JAVA_LANG_DOUBLE
+import com.intellij.psi.CommonClassNames.JAVA_LANG_FLOAT
+import com.intellij.psi.CommonClassNames.JAVA_LANG_INTEGER
+import com.intellij.psi.CommonClassNames.JAVA_LANG_LONG
+import com.intellij.psi.CommonClassNames.JAVA_LANG_SHORT
 import com.intellij.psi.CommonClassNames.JAVA_LANG_STRING
 import com.intellij.psi.CommonClassNames.JAVA_LANG_STRING_SHORT
 import com.intellij.psi.PsiArrayType
@@ -80,8 +89,27 @@ class ConfigValueInspection : MixinConfigInspection() {
                 return value is JsonStringLiteral
             }
 
+            if (type.className == "Boolean" && type.resolve()?.qualifiedName == CommonClassNames.JAVA_LANG_BOOLEAN) {
+                return value is JsonBooleanLiteral || value is JsonNullLiteral
+            }
+
+            if (shortNumberNames.contains(type.className) && qualifiedNumberNames.contains(type.resolve()?.qualifiedName)) {
+                return value is JsonNumberLiteral || value is JsonNullLiteral
+            }
+
             PsiUtil.extractIterableTypeParameter(type, true)?.let { return checkArray(it, value) }
             return value is JsonObject
         }
+
+        private val shortNumberNames = setOf("Byte", "Character", "Double", "Float", "Integer", "Long", "Short")
+        private val qualifiedNumberNames = setOf(
+            JAVA_LANG_BYTE,
+            JAVA_LANG_CHARACTER,
+            JAVA_LANG_DOUBLE,
+            JAVA_LANG_FLOAT,
+            JAVA_LANG_INTEGER,
+            JAVA_LANG_LONG,
+            JAVA_LANG_SHORT
+        )
     }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigValueInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigValueInspection.kt
@@ -93,7 +93,9 @@ class ConfigValueInspection : MixinConfigInspection() {
                 return value is JsonBooleanLiteral || value is JsonNullLiteral
             }
 
-            if (shortNumberNames.contains(type.className) && qualifiedNumberNames.contains(type.resolve()?.qualifiedName)) {
+            if (shortNumberNames.contains(type.className) &&
+                qualifiedNumberNames.contains(type.resolve()?.qualifiedName)
+            ) {
                 return value is JsonNumberLiteral || value is JsonNullLiteral
             }
 


### PR DESCRIPTION
I was always getting an error on `"required": true` in the mixin config, because Mixin changed the type from `boolean` to `Boolean`.