### PR TITLE
Disable EntityConstructorInspection for MC 1.13 onwards

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/McpModuleType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/McpModuleType.kt
@@ -15,6 +15,7 @@ import com.demonwav.mcdev.platform.AbstractModuleType
 import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.mcp.util.McpConstants
 import com.demonwav.mcdev.util.CommonColors
+import com.demonwav.mcdev.util.SemanticVersion
 import javax.swing.Icon
 
 object McpModuleType : AbstractModuleType<McpModule>("", "") {
@@ -33,4 +34,6 @@ object McpModuleType : AbstractModuleType<McpModule>("", "") {
     override val hasIcon = false
 
     override fun generateModule(facet: MinecraftFacet) = McpModule(facet)
+
+    val MC_1_12_2 = SemanticVersion.release(1, 12, 2)
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/inspections/EntityConstructorInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/inspections/EntityConstructorInspection.kt
@@ -14,6 +14,7 @@ import com.demonwav.mcdev.facet.MinecraftFacet
 import com.demonwav.mcdev.platform.mcp.McpModuleType
 import com.demonwav.mcdev.platform.mcp.util.McpConstants
 import com.demonwav.mcdev.platform.mixin.util.isMixin
+import com.demonwav.mcdev.util.SemanticVersion
 import com.demonwav.mcdev.util.extendsOrImplements
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.psi.PsiClass
@@ -49,10 +50,9 @@ class EntityConstructorInspection : BaseInspection() {
                 }
 
                 val module = ModuleUtilCore.findModuleForPsiElement(aClass) ?: return
-
-                val instance = MinecraftFacet.getInstance(module) ?: return
-
-                if (!instance.isOfType(McpModuleType)) {
+                val mcpModule = MinecraftFacet.getInstance(module, McpModuleType) ?: return
+                val mcVersion = mcpModule.getSettings().minecraftVersion
+                if (mcVersion != null && SemanticVersion.parse(mcVersion) > McpModuleType.MC_1_12_2) {
                     return
                 }
 


### PR DESCRIPTION
Since 1.13 Entity classes no longer need a specific constructor, the inspection is therefore wrong for this version onwards.

Fixes #707 