### PR TITLE
Enable bungeecord event listener generation

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/bungeecord/BungeeCordModuleType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/bungeecord/BungeeCordModuleType.kt
@@ -35,6 +35,7 @@ object BungeeCordModuleType : AbstractModuleType<BungeeCordModule<BungeeCordModu
     override val id = ID
     override val ignoredAnnotations = IGNORED_ANNOTATIONS
     override val listenerAnnotations = LISTENER_ANNOTATIONS
+    override val isEventGenAvailable = true
 
     override fun generateModule(facet: MinecraftFacet) = BungeeCordModule(facet, this)
     override fun getEventGenerationPanel(chosenClass: PsiClass) = BungeeCordEventGenerationPanel(chosenClass)


### PR DESCRIPTION
Not sure why this was never done but this enables bungeecord based modules to use event listener generation action.