### PR TITLE
Bukkit: Only use major and minor version for api-version

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/bukkit/creator/BukkitTemplate.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/bukkit/creator/BukkitTemplate.kt
@@ -125,10 +125,11 @@ object BukkitTemplate : BaseTemplate() {
         }
 
         // Plugins targeting 1.13 or newer need an explicit api declaration flag
-        // Unfortunately this flag has no contract to match any specific API version
+        // This is the major and minor version separated by a dot without the patch version. ex: 1.15 even for 1.15.2
         config.minecraftVersion?.let { mcVersion ->
-            if (SemanticVersion.parse(mcVersion) >= BukkitModuleType.API_TAG_VERSION) {
-                props["API_VERSION"] = mcVersion
+            val semVer = SemanticVersion.parse(mcVersion)
+            if (semVer >= BukkitModuleType.API_TAG_VERSION) {
+                props["API_VERSION"] = semVer.take(2).toString()
             }
         }
 


### PR DESCRIPTION
Prior to this change, the patch version was also included in the
api-version flag. This commit makes it only use the major and minor
version, excluding the patch version, as that is not supported notation.

api-version: 1.15.2  ->  api-version: 1.15