### PR TITLE
Add spellcheck support for lang files

### DIFF
--- a/src/main/kotlin/translations/lang/spellcheck/LangCommentTokenizer.kt
+++ b/src/main/kotlin/translations/lang/spellcheck/LangCommentTokenizer.kt
@@ -1,0 +1,29 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2020 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.translations.lang.spellcheck
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.spellchecker.inspections.PlainTextSplitter
+import com.intellij.spellchecker.tokenizer.TokenConsumer
+import com.intellij.spellchecker.tokenizer.Tokenizer
+
+class LangCommentTokenizer : Tokenizer<LeafPsiElement>() {
+    override fun tokenize(element: LeafPsiElement, consumer: TokenConsumer?) {
+        val text = element.text
+        val startOffset = when {
+            text.startsWith('#') -> 1
+            else -> 0
+        }
+        val range = TextRange(startOffset, text.length)
+        consumer?.consumeToken(element, text, false, 0, range, PlainTextSplitter.getInstance())
+    }
+}

--- a/src/main/kotlin/translations/lang/spellcheck/LangCommentTokenizer.kt
+++ b/src/main/kotlin/translations/lang/spellcheck/LangCommentTokenizer.kt
@@ -17,13 +17,13 @@ import com.intellij.spellchecker.tokenizer.TokenConsumer
 import com.intellij.spellchecker.tokenizer.Tokenizer
 
 class LangCommentTokenizer : Tokenizer<LeafPsiElement>() {
-    override fun tokenize(element: LeafPsiElement, consumer: TokenConsumer?) {
+    override fun tokenize(element: LeafPsiElement, consumer: TokenConsumer) {
         val text = element.text
         val startOffset = when {
             text.startsWith('#') -> 1
             else -> 0
         }
         val range = TextRange(startOffset, text.length)
-        consumer?.consumeToken(element, text, false, 0, range, PlainTextSplitter.getInstance())
+        consumer.consumeToken(element, text, false, 0, range, PlainTextSplitter.getInstance())
     }
 }

--- a/src/main/kotlin/translations/lang/spellcheck/LangKeySplitter.kt
+++ b/src/main/kotlin/translations/lang/spellcheck/LangKeySplitter.kt
@@ -16,7 +16,7 @@ import com.intellij.spellchecker.inspections.IdentifierSplitter
 import com.intellij.util.Consumer
 
 object LangKeySplitter : BaseSplitter() {
-    override fun split(text: String?, range: TextRange, consumer: Consumer<TextRange>?) {
+    override fun split(text: String?, range: TextRange, consumer: Consumer<TextRange>) {
         if (text == null) {
             return
         }

--- a/src/main/kotlin/translations/lang/spellcheck/LangKeySplitter.kt
+++ b/src/main/kotlin/translations/lang/spellcheck/LangKeySplitter.kt
@@ -1,3 +1,13 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2020 minecraft-dev
+ *
+ * MIT License
+ */
+
 package com.demonwav.mcdev.translations.lang.spellcheck
 
 import com.intellij.openapi.util.TextRange

--- a/src/main/kotlin/translations/lang/spellcheck/LangKeySplitter.kt
+++ b/src/main/kotlin/translations/lang/spellcheck/LangKeySplitter.kt
@@ -1,0 +1,27 @@
+package com.demonwav.mcdev.translations.lang.spellcheck
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.spellchecker.inspections.BaseSplitter
+import com.intellij.spellchecker.inspections.IdentifierSplitter
+import com.intellij.util.Consumer
+
+object LangKeySplitter : BaseSplitter() {
+    override fun split(text: String?, range: TextRange, consumer: Consumer<TextRange>?) {
+        if (text == null) {
+            return
+        }
+
+        val subText = newBombedCharSequence(text, range)
+        val codepoints = subText.split('.')
+        val idSplitter = IdentifierSplitter.getInstance()
+
+        var index = range.startOffset
+        for (codepoint in codepoints) {
+            checkCancelled()
+            // Use full text with the correct range
+            idSplitter.split(text, TextRange.from(index, codepoint.length), consumer)
+
+            index += codepoint.length + 1 // Add the length of the codepoint plus 1 for the period
+        }
+    }
+}

--- a/src/main/kotlin/translations/lang/spellcheck/LangSpellcheckingStrategy.kt
+++ b/src/main/kotlin/translations/lang/spellcheck/LangSpellcheckingStrategy.kt
@@ -1,0 +1,36 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2020 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.translations.lang.spellcheck
+
+import com.demonwav.mcdev.translations.lang.MCLangLanguage
+import com.demonwav.mcdev.translations.lang.gen.psi.LangTypes
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
+import com.intellij.spellchecker.tokenizer.Tokenizer
+import com.intellij.spellchecker.tokenizer.TokenizerBase
+
+class LangSpellcheckingStrategy : SpellcheckingStrategy() {
+    private val langCommentTokenizer = LangCommentTokenizer()
+    private val langKeyTokenizer = TokenizerBase<LeafPsiElement>(LangKeySplitter)
+
+    override fun isMyContext(element: PsiElement) = MCLangLanguage.`is`(element.language)
+
+    override fun getTokenizer(element: PsiElement?): Tokenizer<*> {
+        return when (element?.node?.elementType) {
+            LangTypes.VALUE -> TEXT_TOKENIZER
+            LangTypes.COMMENT -> langCommentTokenizer
+            LangTypes.EQUALS, LangTypes.LINE_ENDING, LangTypes.ENTRY -> EMPTY_TOKENIZER // Should not be spellchecked
+            LangTypes.KEY, LangTypes.DUMMY -> langKeyTokenizer
+            else -> super.getTokenizer(element)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -114,7 +114,7 @@
         <lang.foldingBuilder language="JAVA" implementationClass="com.demonwav.mcdev.translations.TranslationFoldingBuilder"/>
         <lang.formatter language="MCLang" implementationClass="com.demonwav.mcdev.translations.lang.formatting.LangFormattingModelBuilder"/>
         <lang.commenter language="MCLang" implementationClass="com.demonwav.mcdev.translations.lang.LangCommenter" />
-        <spellchecker.support language="MCLang" implementationClass="com.demonwav.mcdev.translations.spellcheck.LangSpellcheckingStrategy"/>
+        <spellchecker.support language="MCLang" implementationClass="com.demonwav.mcdev.translations.lang.spellcheck.LangSpellcheckingStrategy"/>
         <psi.referenceContributor language="JAVA" implementation="com.demonwav.mcdev.translations.reference.JavaReferenceContributor"/>
         <psi.referenceContributor language="MCLang" implementation="com.demonwav.mcdev.translations.reference.LangReferenceContributor"/>
         <psi.referenceContributor language="JSON" implementation="com.demonwav.mcdev.translations.reference.JsonReferenceContributor"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -114,6 +114,7 @@
         <lang.foldingBuilder language="JAVA" implementationClass="com.demonwav.mcdev.translations.TranslationFoldingBuilder"/>
         <lang.formatter language="MCLang" implementationClass="com.demonwav.mcdev.translations.lang.formatting.LangFormattingModelBuilder"/>
         <lang.commenter language="MCLang" implementationClass="com.demonwav.mcdev.translations.lang.LangCommenter" />
+        <spellchecker.support language="MCLang" implementationClass="com.demonwav.mcdev.translations.spellcheck.LangSpellcheckingStrategy"/>
         <psi.referenceContributor language="JAVA" implementation="com.demonwav.mcdev.translations.reference.JavaReferenceContributor"/>
         <psi.referenceContributor language="MCLang" implementation="com.demonwav.mcdev.translations.reference.LangReferenceContributor"/>
         <psi.referenceContributor language="JSON" implementation="com.demonwav.mcdev.translations.reference.JsonReferenceContributor"/>


### PR DESCRIPTION
This PR adds support for spellchecking in language files. I have tested this and confirmed it to work. I'm not the best at Kotlin, but I was using IntelliJ IDEA and don't think I programmed anything too particularly badly. I also ran `gradle format` already.

Specifically, the `LangSpellcheckingStrategy` class I implemented adds custom support for comments, translations keys, and their corresponding values.
* Translation keys (and dummy keys without a value) are treated as special identifiers, which are split by `.` and then parsed using `IdentifierSplitter`. The `IdentifierSplitter` is the same splitter used on variable names, so has inbuilt support for camelCase.
* Translation values are treated as normal plain text and parsed using `PlainTextSplitter`.
* Comments are treated as normal plain text, excluding the `#` that precedes the comment.
* Equal signs, Line endings, and the overarching entry types are skipped from tokenization/spellchecking.

Please let me know what you think; I spent a good amount of time working on this side project. I enjoyed it as I got to learn a bit of Kotlin as well as a very small view of the infrastructure of an IntelliJ plugin. I am happy to make any other changes that are suggested.