### PR TITLE
[Mixin] Always enable "Fix method parameters" fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,6 +227,7 @@ license {
     exclude(
         "com/demonwav/mcdev/platform/mcp/at/gen/**",
         "com/demonwav/mcdev/nbt/lang/gen/**",
+        "com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/*.java",
         "com/demonwav/mcdev/translations/lang/gen/**"
     )
 

--- a/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
@@ -83,7 +83,7 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
                             holder.registerProblem(
                                 parameters,
                                 "Method parameters do not match expected parameters for ${type.annotationName}",
-                                ParametersQuickFix(expectedParameters)
+                                ParametersQuickFix(expectedParameters, type)
                             )
                         }
 
@@ -120,9 +120,17 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
         }
     }
 
-    private class ParametersQuickFix(private val expected: List<ParameterGroup>) : LocalQuickFix {
+    private class ParametersQuickFix(
+        private val expected: List<ParameterGroup>,
+        injectorType: InjectorType
+    ) : LocalQuickFix {
 
-        override fun getFamilyName() = "Fix method parameters"
+        private val fixName = when (injectorType) {
+            InjectorType.INJECT -> "Fix method parameters"
+            else -> "Fix method parameters (won't keep captured locals)"
+        }
+
+        override fun getFamilyName() = fixName
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
             val parameters = descriptor.psiElement as PsiParameterList

--- a/src/test/kotlin/framework/test-util.kt
+++ b/src/test/kotlin/framework/test-util.kt
@@ -86,8 +86,8 @@ fun ProjectBuilderTest.testParser(basePath: String, func: ProjectBuilderFunc) {
 
 fun testInspectionFix(fixture: JavaCodeInsightTestFixture, basePath: String, fixName: String) {
     val caller = ReflectionUtil.getCallerClass(4)!!
-    val original = caller.getResource("$basePath.java").readText().trim()
-    val expected = caller.getResource("$basePath.after.java").readText().trim()
+    val original = caller.getResource("$basePath.java").readText().trim().lineSequence().joinToString("\n")
+    val expected = caller.getResource("$basePath.after.java").readText().trim().lineSequence().joinToString("\n")
 
     fixture.configureByText(JavaFileType.INSTANCE, original)
     val intention = fixture.findSingleIntention(fixName)

--- a/src/test/kotlin/framework/test-util.kt
+++ b/src/test/kotlin/framework/test-util.kt
@@ -12,6 +12,7 @@
 
 package com.demonwav.mcdev.framework
 
+import com.intellij.ide.highlighter.JavaFileType
 import com.intellij.lexer.Lexer
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.OrderRootType
@@ -24,6 +25,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.DebugUtil
 import com.intellij.testFramework.LexerTestCase
+import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture
 import com.intellij.util.ReflectionUtil
 import org.junit.jupiter.api.Assertions
 
@@ -80,4 +82,15 @@ fun ProjectBuilderTest.testParser(basePath: String, func: ProjectBuilderFunc) {
     val expectedLines = expected.lineSequence().filter { it.isNotBlank() }.toList()
     val actualLines = actual.lineSequence().filter { it.isNotBlank() }.toList()
     Assertions.assertLinesMatch(expectedLines, actualLines)
+}
+
+fun testInspectionFix(fixture: JavaCodeInsightTestFixture, basePath: String, fixName: String) {
+    val caller = ReflectionUtil.getCallerClass(4)!!
+    val original = caller.getResource("$basePath.java").readText().trim()
+    val expected = caller.getResource("$basePath.after.java").readText().trim()
+
+    fixture.configureByText(JavaFileType.INSTANCE, original)
+    val intention = fixture.findSingleIntention(fixName)
+    fixture.launchAction(intention)
+    fixture.checkResult(expected)
 }

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
@@ -79,4 +79,8 @@ class InvalidInjectorMethodSignatureFixTest : BaseMixinTest() {
     @Test
     @DisplayName("Inner ctor with locals")
     fun innerCtorWithLocals() = doTest("innerCtorWithLocals")
+
+    @Test
+    @DisplayName("Inject without CallbackInfo")
+    fun injectWithoutCI() = doTest("injectWithoutCI")
 }

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2020 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin
+
+import com.demonwav.mcdev.framework.EdtInterceptor
+import com.demonwav.mcdev.framework.testInspectionFix
+import com.demonwav.mcdev.platform.mixin.inspection.injector.InvalidInjectorMethodSignatureInspection
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(EdtInterceptor::class)
+@DisplayName("Invalid Injector Method Signature Inspection Test")
+class InvalidInjectorMethodSignatureFixTest : BaseMixinTest() {
+
+    private fun doTest(testName: String) {
+        buildProject {
+            dir("test") {
+                java(
+                    "MixedInSimple.java",
+                    """
+                    package test;
+                    
+                    import java.lang.String;
+
+                    class MixedInSimple {
+                        public void simpleMethod(String string, int i) {
+                        }
+                    }
+                    """,
+                    configure = false
+                )
+                java(
+                    "MixedInOuter.java",
+                    """
+                    package test;
+                    
+                    import java.lang.String;
+
+                    class MixedInOuter {
+                        public class MixedInInner {
+                            public MixedInInner() {
+                            }
+                            
+                            public MixedInInner(String string) {
+                            }
+                        }
+                    }
+                    """,
+                    configure = false
+                )
+            }
+        }
+
+        fixture.enableInspections(InvalidInjectorMethodSignatureInspection::class)
+        testInspectionFix(fixture, "invalidInjectorMethodSignature/$testName", "Fix method parameters")
+    }
+
+    @Test
+    @DisplayName("Simple case")
+    fun simpleCase() = doTest("simpleCase")
+
+    @Test
+    @DisplayName("With captured locals")
+    fun withCapturedLocals() = doTest("withCapturedLocals")
+
+    @Test
+    @DisplayName("Simple inner ctor")
+    fun simpleInnerCtor() = doTest("simpleInnerCtor")
+
+    @Test
+    @DisplayName("Inner ctor with locals")
+    fun innerCtorWithLocals() = doTest("innerCtorWithLocals")
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/injectWithoutCI.after.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/injectWithoutCI.after.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, int i, CallbackInfo ci<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/injectWithoutCI.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/injectWithoutCI.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, String invalidLocal<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/innerCtorWithLocals.after.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/innerCtorWithLocals.after.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInOuter.MixedInInner.class)
+public class TestMixin {
+
+    @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))
+    private void injectCtor(MixedInOuter outer, String string, CallbackInfo ci, String local1, float local2, int local3<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/innerCtorWithLocals.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/innerCtorWithLocals.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInOuter.MixedInInner.class)
+public class TestMixin {
+
+    @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))
+    private void injectCtor(CallbackInfo ci<caret>, String local1, float local2, int local3) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCase.after.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCase.after.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, int i, CallbackInfo ci<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCase.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCase.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, CallbackInfo ci<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleInnerCtor.after.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleInnerCtor.after.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInOuter.MixedInInner.class)
+public class TestMixin {
+
+    @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))
+    private void injectCtor(MixedInOuter outer, String string, CallbackInfo ci<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleInnerCtor.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleInnerCtor.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInOuter.MixedInInner.class)
+public class TestMixin {
+
+    @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))
+    private void injectCtor(CallbackInfo ci<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/withCapturedLocals.after.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/withCapturedLocals.after.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, int i, CallbackInfo ci, String local1, float local2, int local3<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/withCapturedLocals.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/withCapturedLocals.java
@@ -1,0 +1,14 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, CallbackInfo ci<caret>, String local1, float local2, int local3) {
+    }
+}


### PR DESCRIPTION
The fix now keeps every parameters after the CallbackInfo to not remove captured locals.

I am not sure if my solution is entirely correct, let me know if there are cases where it won't work.

Fixes #766 