### PR TITLE
Use plugins block instead of apply plugin in gradle build scripts

### DIFF
--- a/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit Submodule build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit Submodule build.gradle.ft
@@ -1,4 +1,6 @@
-apply plugin: 'com.github.johnrengelman.shadow'
+plugins {
+    id 'com.github.johnrengelman.shadow'
+}
 
 repositories {
 }

--- a/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit build.gradle.ft
@@ -1,6 +1,8 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
-apply plugin: 'java'
+plugins {
+    id 'java'
+}
 
 group = '${GROUP_ID}'
 version = '${PLUGIN_VERSION}'


### PR DESCRIPTION
Currently, this change only affects Bukkit project creation.

Keeping it simple for my first PR on this project. I'm less familiar with the other platform tooling setups, so I didn't change them yet to use the plugins block. That said, if I'd be able to get a hand making sure things don't break on those other platforms, I'd gladly throw them in, I've already done some basic testing of this change and it seems to behave as desired in that it produces the build script using the plugins block and doesn't crash.

Not included currently but were discussed in the Discord server: gradle version bump.

If it is reasonable to pack some additional changes into this PR, I'm happy to do so, but I tend to favor keeping PRs as nice bite sized change sets when possible. Any feedback is appreciated (yes, I realize it is literally a few lines in a template and there is more text here than in the code difference itself).