### PR TITLE
Port some features shared by all frameworks to UAST

### DIFF
--- a/src/main/kotlin/insight/ColorAnnotator.kt
+++ b/src/main/kotlin/insight/ColorAnnotator.kt
@@ -18,6 +18,8 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.psi.PsiElement
 import java.awt.Color
 import java.awt.Font
+import org.jetbrains.uast.UIdentifier
+import org.jetbrains.uast.toUElementOfType
 
 class ColorAnnotator : Annotator {
 
@@ -26,7 +28,7 @@ class ColorAnnotator : Annotator {
             return
         }
 
-        val color = element.findColor { _, chosenEntry -> chosenEntry.value } ?: return
+        val color = element.toUElementOfType<UIdentifier>()?.findColor { _, chosenEntry -> chosenEntry.value } ?: return
 
         setColorAnnotator(color, element, holder)
     }

--- a/src/main/kotlin/insight/ColorUtil.kt
+++ b/src/main/kotlin/insight/ColorUtil.kt
@@ -13,30 +13,30 @@ package com.demonwav.mcdev.insight
 import com.demonwav.mcdev.facet.MinecraftFacet
 import com.demonwav.mcdev.platform.AbstractModule
 import com.demonwav.mcdev.platform.AbstractModuleType
+import com.demonwav.mcdev.util.findModule
 import com.demonwav.mcdev.util.runWriteAction
 import com.intellij.openapi.module.ModuleUtilCore
-import com.intellij.psi.JavaPsiFacade
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiExpressionList
-import com.intellij.psi.PsiIdentifier
-import com.intellij.psi.PsiLiteralExpression
-import com.intellij.psi.PsiMethodCallExpression
-import com.intellij.psi.PsiNewExpression
-import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.JVMElementFactories
 import com.intellij.psi.PsiType
-import com.intellij.psi.impl.source.tree.JavaElementType
 import com.intellij.psi.search.GlobalSearchScope
 import java.awt.Color
+import kotlin.math.round
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UIdentifier
+import org.jetbrains.uast.ULiteralExpression
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.UReferenceExpression
+import org.jetbrains.uast.generate.generationPlugin
+import org.jetbrains.uast.generate.replace
 
-fun <T> PsiElement.findColor(function: (Map<String, Color>, Map.Entry<String, Color>) -> T): T? {
-    if (this !is PsiIdentifier) {
-        return null
-    }
+fun <T> UIdentifier.findColor(function: (Map<String, Color>, Map.Entry<String, Color>) -> T): T? {
+    val parent = this.uastParent
+    val expression = parent as? UReferenceExpression ?: return null
+    val type = expression.getExpressionType() ?: return null
 
-    val expression = this.parent as? PsiReferenceExpression ?: return null
-    val type = expression.type ?: return null
-
-    val module = ModuleUtilCore.findModuleForPsiElement(this) ?: return null
+    val module = this.sourcePsi?.findModule() ?: return null
     val facet = MinecraftFacet.getInstance(module) ?: return null
     for (abstractModuleType in facet.types) {
         val map = abstractModuleType.classToColorMappings
@@ -45,7 +45,9 @@ fun <T> PsiElement.findColor(function: (Map<String, Color>, Map.Entry<String, Co
             // Okay, type will be the fully-qualified class, but it will exclude the actual enum
             // the expression will be the non-fully-qualified class with the enum
             // So we combine those checks and get this
-            if (entry.key.startsWith(type.canonicalText) && entry.key.endsWith(expression.canonicalText)) {
+            val colorClass = entry.key.substringBeforeLast('.')
+            val colorName = entry.key.substringAfterLast('.')
+            if (colorClass.startsWith(type.canonicalText) && colorName == expression.resolvedName ?: continue) {
                 return function(map, entry)
             }
         }
@@ -53,18 +55,15 @@ fun <T> PsiElement.findColor(function: (Map<String, Color>, Map.Entry<String, Co
     return null
 }
 
-fun PsiElement.findColor(
+fun UIdentifier.findColor(
     moduleType: AbstractModuleType<AbstractModule>,
     className: String,
     vectorClasses: Array<String>?
-): Pair<Color, PsiElement>? {
-    if (this !is PsiIdentifier) {
-        return null
-    }
+): Pair<Color, UElement>? {
+    val sourcePsi = this.sourcePsi ?: return null
+    val project = sourcePsi.project
 
-    val project = this.getProject()
-
-    val module = ModuleUtilCore.findModuleForPsiElement(this) ?: return null
+    val module = ModuleUtilCore.findModuleForPsiElement(sourcePsi) ?: return null
 
     val facet = MinecraftFacet.getInstance(module) ?: return null
 
@@ -72,118 +71,106 @@ fun PsiElement.findColor(
         return null
     }
 
-    val methodExpression = this.parent as? PsiReferenceExpression ?: return null
-    val qualifier = methodExpression.qualifier as? PsiReferenceExpression ?: return null
-    if (qualifier.qualifiedName != className) {
+    val methodExpression = uastParent as? UCallExpression ?: return null
+    if (methodExpression.resolve()?.containingClass?.qualifiedName != className) {
         return null
     }
 
-    val methodCallExpression = methodExpression.parent as? PsiMethodCallExpression ?: return null
-    val expressionList = methodCallExpression.argumentList
-    val types = expressionList.expressionTypes
+    val arguments = methodExpression.valueArguments
+    val types = arguments.map(UExpression::getExpressionType)
 
-    when {
+    return when {
         // Single Integer Argument
-        types.size == 1 && types[0] == PsiType.INT && expressionList.expressions[0] is PsiLiteralExpression -> {
-            try {
-                val expr = expressionList.expressions[0] as PsiLiteralExpression
-                return colorFromSingleArgument(expr) to expressionList.expressions[0]
-            } catch (ignored: Exception) { }
-        }
+        types.size == 1 && types[0] == PsiType.INT ->
+            colorFromSingleArgument(arguments[0])?.let { it to arguments[0] }
         // Triple Integer Argument
-        types.size == 3 && types[0] == PsiType.INT && types[1] == PsiType.INT && types[2] == PsiType.INT -> {
-            try {
-                return colorFromThreeArguments(expressionList) to expressionList
-            } catch (ignored: Exception) { }
-        }
+        types.size == 3 && types.all { it == PsiType.INT } ->
+            colorFromThreeArguments(arguments)?.let { it to methodExpression }
         vectorClasses != null && types.size == 1 -> {
             val scope = GlobalSearchScope.allScope(project)
-            for (vectorClass in vectorClasses) {
-                if (types[0] == PsiType.getTypeByName(vectorClass, project, scope)) {
-                    try {
-                        val color = colorFromVectorArgument(expressionList.expressions[0] as PsiNewExpression)
-                        return color to expressionList.expressions[0]
-                    } catch (ignored: Exception) {}
-                }
+            if (vectorClasses.any { types[0] == PsiType.getTypeByName(it, project, scope) }) {
+                (arguments[0] as? UCallExpression)?.takeIf { it.valueArgumentCount == 3 }
+                    ?.let(::colorFromVectorArgument)
+                    ?.let { it to arguments[0] }
+            } else {
+                null
+            }
+        }
+        else -> null
+    }
+}
+
+private fun colorFromSingleArgument(expression: UExpression): Color? {
+    return Color(expression.evaluate() as? Int ?: return null)
+}
+
+private fun colorFromThreeArguments(expressions: List<UExpression>): Color? {
+    fun normalize(value: Any?): Int? = when (value) {
+        is Int -> value
+        is Float -> round(value).toInt()
+        is Double -> round(value).toInt()
+        else -> null
+    }
+
+    val r = normalize(expressions[0].evaluate()) ?: return null
+    val g = normalize(expressions[1].evaluate()) ?: return null
+    val b = normalize(expressions[2].evaluate()) ?: return null
+    return Color(r, g, b)
+}
+
+private fun colorFromVectorArgument(newExpression: UCallExpression): Color? {
+    return colorFromThreeArguments(newExpression.valueArguments)
+}
+
+fun UElement.setColor(color: String) {
+    val sourcePsi = this.sourcePsi ?: return
+    sourcePsi.containingFile.runWriteAction {
+        val project = sourcePsi.project
+        val parent = this.uastParent
+        val newColorRef = generationPlugin?.getElementFactory(project)?.createQualifiedReference(color, this)
+            ?: return@runWriteAction
+        if (this.lang.id == "kotlin") {
+            // Kotlin UAST is a bit different, annoying but I couldn't find a better way
+            val grandparent = parent?.uastParent
+            if (grandparent is UQualifiedReferenceExpression) {
+                grandparent.replace(newColorRef)
+            } else {
+                this.replace(newColorRef)
+            }
+        } else {
+            if (parent is UQualifiedReferenceExpression) {
+                parent.replace(newColorRef)
+            } else {
+                this.replace(newColorRef)
             }
         }
     }
-
-    return null
 }
 
-fun PsiElement.setColor(color: String) {
-    this.containingFile.runWriteAction {
-        val split = color.split(".").dropLastWhile(String::isEmpty).toTypedArray()
-        val newColorBase = split.last()
-
-        val identifier = JavaPsiFacade.getElementFactory(this.project).createIdentifier(newColorBase)
-
-        this.replace(identifier)
+fun ULiteralExpression.setColor(value: Int) {
+    val sourcePsi = this.sourcePsi ?: return
+    sourcePsi.containingFile.runWriteAction {
+        JVMElementFactories.requireFactory(sourcePsi.language, sourcePsi.project)
+            .createExpressionFromText("0x" + Integer.toHexString(value).toUpperCase(), sourcePsi)
+            .let(sourcePsi::replace)
     }
 }
 
-fun PsiLiteralExpression.setColor(value: Int) {
-    this.containingFile.runWriteAction {
-        val node = this.node
+fun UCallExpression.setColor(red: Int, green: Int, blue: Int) {
+    val sourcePsi = this.sourcePsi ?: return
+    sourcePsi.containingFile.runWriteAction {
+        val r = this.valueArguments[0]
+        val g = this.valueArguments[1]
+        val b = this.valueArguments[2]
 
-        val literalExpression = JavaPsiFacade.getElementFactory(this.project)
-            .createExpressionFromText("0x" + Integer.toHexString(value).toUpperCase(), null) as PsiLiteralExpression
+        val factory = JVMElementFactories.requireFactory(sourcePsi.language, sourcePsi.project)
 
-        node.psi.replace(literalExpression)
+        val literalExpressionOne = factory.createExpressionFromText(red.toString(), null)
+        val literalExpressionTwo = factory.createExpressionFromText(green.toString(), null)
+        val literalExpressionThree = factory.createExpressionFromText(blue.toString(), null)
+
+        r.sourcePsi?.replace(literalExpressionOne)
+        g.sourcePsi?.replace(literalExpressionTwo)
+        b.sourcePsi?.replace(literalExpressionThree)
     }
-}
-
-fun PsiExpressionList.setColor(red: Int, green: Int, blue: Int) {
-    this.containingFile.runWriteAction {
-        val expressionOne = this.expressions[0]
-        val expressionTwo = this.expressions[1]
-        val expressionThree = this.expressions[2]
-
-        val nodeOne = expressionOne.node
-        val nodeTwo = expressionTwo.node
-        val nodeThree = expressionThree.node
-
-        val facade = JavaPsiFacade.getElementFactory(this.project)
-
-        val literalExpressionOne = facade.createExpressionFromText(red.toString(), null)
-        val literalExpressionTwo = facade.createExpressionFromText(green.toString(), null)
-        val literalExpressionThree = facade.createExpressionFromText(blue.toString(), null)
-
-        nodeOne.psi.replace(literalExpressionOne)
-        nodeTwo.psi.replace(literalExpressionTwo)
-        nodeThree.psi.replace(literalExpressionThree)
-    }
-}
-
-private fun colorFromSingleArgument(expression: PsiLiteralExpression): Color {
-    val value = Integer.decode(expression.text)!!
-
-    return Color(value)
-}
-
-private fun colorFromThreeArguments(expressionList: PsiExpressionList): Color {
-    if (expressionList.expressions[0] !is PsiLiteralExpression ||
-        expressionList.expressions[1] !is PsiLiteralExpression ||
-        expressionList.expressions[2] !is PsiLiteralExpression
-    ) {
-        throw Exception()
-    }
-
-    val expressionOne = expressionList.expressions[0] as PsiLiteralExpression
-    val expressionTwo = expressionList.expressions[1] as PsiLiteralExpression
-    val expressionThree = expressionList.expressions[2] as PsiLiteralExpression
-
-    val one = Math.round(expressionOne.text.toDouble()).toInt()
-    val two = Math.round(expressionTwo.text.toDouble()).toInt()
-    val three = Math.round(expressionThree.text.toDouble()).toInt()
-
-    return Color(one, two, three)
-}
-
-private fun colorFromVectorArgument(newExpression: PsiNewExpression): Color {
-    val expressionList =
-        newExpression.node.findChildByType(JavaElementType.EXPRESSION_LIST) as PsiExpressionList? ?: throw Exception()
-
-    return colorFromThreeArguments(expressionList)
 }

--- a/src/main/kotlin/insight/ColorUtil.kt
+++ b/src/main/kotlin/insight/ColorUtil.kt
@@ -48,7 +48,7 @@ fun <T> UIdentifier.findColor(function: (Map<String, Color>, Map.Entry<String, C
             val colorClass = entry.key.substringBeforeLast('.')
             val colorName = entry.key.substringAfterLast('.')
             if (colorClass.startsWith(type.canonicalText) && colorName == expression.resolvedName ?: continue) {
-                return function(map, entry)
+                return function(map.filterKeys { key -> key.startsWith(colorClass) }, entry)
             }
         }
     }

--- a/src/main/kotlin/insight/InsightUtil.kt
+++ b/src/main/kotlin/insight/InsightUtil.kt
@@ -57,6 +57,7 @@ val UMethod.uastEventParameterPair: Pair<UParameter, UClass>?
         val firstParameter = this.uastParameters.firstOrNull()
             ?: return null // Listeners must have at least a single parameter
         // Get the type of the parameter so we can start resolving it
+
         @Suppress("UElementAsPsi") // UVariable overrides getType so it should be fine to use on UElements...
         val type = firstParameter.type as? PsiClassType ?: return null
         // Validate that it is a class reference type

--- a/src/main/kotlin/insight/ListenerEventAnnotator.kt
+++ b/src/main/kotlin/insight/ListenerEventAnnotator.kt
@@ -80,12 +80,10 @@ class ListenerEventAnnotator : Annotator {
             return
         }
 
-        if (!instance.isStaticListenerSupported(method.javaPsi) && method.isStatic) {
-            method.javaPsi.nameIdentifier?.let {
-                holder.newAnnotation(HighlightSeverity.ERROR, "Event listener method must not be static")
-                    .range(it)
-                    .create()
-            }
+        if (method.isStatic && element.toUElement()?.uastParent is UMethod &&
+            !instance.isStaticListenerSupported(method.javaPsi)
+        ) {
+            holder.newAnnotation(HighlightSeverity.ERROR, "Event listener method must not be static").create()
         }
 
         if (element.getUastParentOfType<UParameter>()?.sourcePsi == eventParameter.sourcePsi &&

--- a/src/main/kotlin/insight/ListenerEventAnnotator.kt
+++ b/src/main/kotlin/insight/ListenerEventAnnotator.kt
@@ -17,12 +17,18 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
-import com.intellij.psi.PsiParameter
-import com.intellij.psi.impl.source.PsiClassReferenceType
+import org.jetbrains.uast.UIdentifier
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UParameter
+import org.jetbrains.uast.UTypeReferenceExpression
+import org.jetbrains.uast.getParentOfType
+import org.jetbrains.uast.getUastParentOfType
+import org.jetbrains.uast.toUElement
+import org.jetbrains.uast.toUElementOfType
 
 class ListenerEventAnnotator : Annotator {
 
@@ -32,18 +38,19 @@ class ListenerEventAnnotator : Annotator {
         }
 
         // Since we want to line up with the method declaration, not the annotation
-        // declaration, we need to target identifiers, not just PsiMethods.
-        val method = when (element) {
-            is PsiIdentifier -> element.parent as? PsiMethod ?: return
-            is PsiParameter -> element.parent.parent as? PsiMethod ?: return
-            else -> return
+        // declaration, we need to target identifiers, not the whole method.
+        if (element.toUElementOfType<UIdentifier>() == null) {
+            return
         }
 
-        if (method.hasModifierProperty(PsiModifier.ABSTRACT)) {
+        val method: UMethod = element.toUElement()?.uastParent as? UMethod
+            ?: element.getUastParentOfType<UTypeReferenceExpression>()
+                ?.getParentOfType<UParameter>()?.uastParent as? UMethod // Be sure to be on the type of a parameter
+            ?: return
+        if (method.javaPsi.hasModifierProperty(PsiModifier.ABSTRACT)) {
             // I don't think any implementation allows for abstract
             return
         }
-        val modifierList = method.modifierList
         val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return
         val instance = MinecraftFacet.getInstance(module) ?: return
         // Since each platform has their own valid listener annotations,
@@ -53,7 +60,7 @@ class ListenerEventAnnotator : Annotator {
         for (moduleType in moduleTypes) {
             val listenerAnnotations = moduleType.listenerAnnotations
             for (listenerAnnotation in listenerAnnotations) {
-                if (modifierList.findAnnotation(listenerAnnotation) != null) {
+                if (method.findAnnotation(listenerAnnotation) != null) {
                     contains = true
                     break
                 }
@@ -63,35 +70,28 @@ class ListenerEventAnnotator : Annotator {
             return
         }
 
-        val parameters = method.parameterList.parameters
-        if (parameters.isEmpty()) {
-            return
-        }
-        val eventParameter = parameters[0] // Listeners must have at least a single parameter
+        val eventParameter = method.uastParameters.firstOrNull() // Listeners must have at least one parameter
             ?: return
-        // Get the type of the parameter so we can start resolving it
-        val psiEventElement = eventParameter.typeElement ?: return
-        val type = psiEventElement.type as? PsiClassReferenceType ?: return
-        // Validate that it is a class reference type
+        // Validate that this is a class reference type
         // And again, make sure that we can at least resolve the type, otherwise it's not a valid
         // class reference.
-        val eventClass = type.resolve() ?: return
-
-        if (instance.isEventClassValid(eventClass, method)) {
+        val eventClass = (eventParameter.typeReference?.type as? PsiClassType)?.resolve() ?: return
+        if (instance.isEventClassValid(eventClass, method.javaPsi)) {
             return
         }
 
-        if (!instance.isStaticListenerSupported(method) && method.hasModifierProperty(PsiModifier.STATIC)) {
-            if (method.nameIdentifier != null) {
+        if (!instance.isStaticListenerSupported(method.javaPsi) && method.isStatic) {
+            method.javaPsi.nameIdentifier?.let {
                 holder.newAnnotation(HighlightSeverity.ERROR, "Event listener method must not be static")
-                    .range(method.nameIdentifier!!)
+                    .range(it)
                     .create()
             }
         }
 
-        if (element == eventParameter && !isSuperEventListenerAllowed(eventClass, method, instance)) {
-            // Only annotate the first parameter
-            val errorMessage = instance.writeErrorMessageForEvent(eventClass, method)
+        if (element.getUastParentOfType<UParameter>()?.sourcePsi == eventParameter.sourcePsi &&
+            !isSuperEventListenerAllowed(eventClass, method.javaPsi, instance)
+        ) {
+            val errorMessage = instance.writeErrorMessageForEvent(eventClass, method.javaPsi)
             if (errorMessage == null) {
                 holder.newSilentAnnotation(HighlightSeverity.ERROR).create()
             } else {

--- a/src/main/kotlin/platform/adventure/color/AdventureColorLineMarkerProvider.kt
+++ b/src/main/kotlin/platform/adventure/color/AdventureColorLineMarkerProvider.kt
@@ -13,7 +13,8 @@ package com.demonwav.mcdev.platform.adventure.color
 import com.demonwav.mcdev.insight.ColorLineMarkerProvider
 import com.intellij.psi.PsiElement
 import java.awt.Color
+import org.jetbrains.uast.UElement
 
 class AdventureColorLineMarkerProvider : ColorLineMarkerProvider.CommonLineMarkerProvider() {
-    override fun findColor(element: PsiElement): Pair<Color, PsiElement>? = element.findAdventureColor()
+    override fun findColor(element: PsiElement): Pair<Color, UElement>? = element.findAdventureColor()
 }

--- a/src/main/kotlin/platform/adventure/color/AdventureColorUtil.kt
+++ b/src/main/kotlin/platform/adventure/color/AdventureColorUtil.kt
@@ -15,6 +15,9 @@ import com.demonwav.mcdev.platform.adventure.AdventureConstants
 import com.demonwav.mcdev.platform.adventure.AdventureModuleType
 import com.intellij.psi.PsiElement
 import java.awt.Color
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UIdentifier
+import org.jetbrains.uast.toUElementOfType
 
-fun PsiElement.findAdventureColor(): Pair<Color, PsiElement>? =
-    findColor(AdventureModuleType, AdventureConstants.TEXT_COLOR_CLASS, null)
+fun PsiElement.findAdventureColor(): Pair<Color, UElement>? =
+    this.toUElementOfType<UIdentifier>()?.findColor(AdventureModuleType, AdventureConstants.TEXT_COLOR_CLASS, null)

--- a/src/main/kotlin/platform/bukkit/util/BukkitConstants.kt
+++ b/src/main/kotlin/platform/bukkit/util/BukkitConstants.kt
@@ -17,7 +17,7 @@ object BukkitConstants {
     const val LISTENER_CLASS = "org.bukkit.event.Listener"
     const val CHAT_COLOR_CLASS = "org.bukkit.ChatColor"
     const val EVENT_CLASS = "org.bukkit.event.Event"
-    const val JAVA_PLUGIN = "org.bukkit.plugin.java.JavaPlugin"
+    const val PLUGIN = "org.bukkit.plugin.Plugin"
     const val EVENT_ISCANCELLED_METHOD_NAME = "isCancelled"
     const val CANCELLABLE_CLASS = "org.bukkit.event.Cancellable"
 }

--- a/src/main/kotlin/platform/liteloader/LiteLoaderModule.kt
+++ b/src/main/kotlin/platform/liteloader/LiteLoaderModule.kt
@@ -19,8 +19,10 @@ import com.demonwav.mcdev.util.SourceType
 import com.demonwav.mcdev.util.nullable
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UIdentifier
+import org.jetbrains.uast.toUElementOfType
 
 class LiteLoaderModule internal constructor(facet: MinecraftFacet) : AbstractModule(facet) {
 
@@ -35,10 +37,11 @@ class LiteLoaderModule internal constructor(facet: MinecraftFacet) : AbstractMod
 
     override fun writeErrorMessageForEventParameter(eventClass: PsiClass, method: PsiMethod) = ""
 
-    override fun shouldShowPluginIcon(element: PsiElement?) =
-        element is PsiIdentifier &&
-            element.parent is PsiClass &&
-            element.text.startsWith("LiteMod")
+    override fun shouldShowPluginIcon(element: PsiElement?): Boolean {
+        val identifier = element?.toUElementOfType<UIdentifier>()
+            ?: return false
+        return identifier.uastParent is UClass && identifier.name.startsWith("LiteMod")
+    }
 
     override fun dispose() {
         super.dispose()

--- a/src/main/kotlin/platform/sponge/color/SpongeColorLineMarkerProvider.kt
+++ b/src/main/kotlin/platform/sponge/color/SpongeColorLineMarkerProvider.kt
@@ -13,7 +13,8 @@ package com.demonwav.mcdev.platform.sponge.color
 import com.demonwav.mcdev.insight.ColorLineMarkerProvider
 import com.intellij.psi.PsiElement
 import java.awt.Color
+import org.jetbrains.uast.UElement
 
 class SpongeColorLineMarkerProvider : ColorLineMarkerProvider.CommonLineMarkerProvider() {
-    override fun findColor(element: PsiElement): Pair<Color, PsiElement>? = element.findSpongeColor()
+    override fun findColor(element: PsiElement): Pair<Color, UElement>? = element.findSpongeColor()
 }

--- a/src/main/kotlin/platform/sponge/color/SpongeColorUtil.kt
+++ b/src/main/kotlin/platform/sponge/color/SpongeColorUtil.kt
@@ -14,9 +14,12 @@ import com.demonwav.mcdev.insight.findColor
 import com.demonwav.mcdev.platform.sponge.SpongeModuleType
 import com.intellij.psi.PsiElement
 import java.awt.Color
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UIdentifier
+import org.jetbrains.uast.toUElementOfType
 
-fun PsiElement.findSpongeColor(): Pair<Color, PsiElement>? =
-    findColor(
+fun PsiElement.findSpongeColor(): Pair<Color, UElement>? =
+    this.toUElementOfType<UIdentifier>()?.findColor(
         SpongeModuleType,
         "org.spongepowered.api.util.Color",
         arrayOf(

--- a/src/main/kotlin/platform/velocity/VelocityModule.kt
+++ b/src/main/kotlin/platform/velocity/VelocityModule.kt
@@ -18,14 +18,17 @@ import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.velocity.generation.VelocityGenerationData
 import com.demonwav.mcdev.platform.velocity.util.VelocityConstants
 import com.demonwav.mcdev.platform.velocity.util.VelocityConstants.SUBSCRIBE_ANNOTATION
+import com.intellij.lang.jvm.JvmModifier
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiType
 import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UIdentifier
+import org.jetbrains.uast.toUElementOfType
 
 class VelocityModule(facet: MinecraftFacet) : AbstractModule(facet) {
     override val moduleType = VelocityModuleType
@@ -71,11 +74,13 @@ class VelocityModule(facet: MinecraftFacet) : AbstractModule(facet) {
     }
 
     override fun shouldShowPluginIcon(element: PsiElement?): Boolean {
-        if (element !is PsiIdentifier) {
-            return false
-        }
+        val identifier = element?.toUElementOfType<UIdentifier>()
+            ?: return false
 
-        val psiClass = element.parent as? PsiClass ?: return false
-        return psiClass.hasAnnotation(VelocityConstants.PLUGIN_ANNOTATION)
+        val psiClass = identifier.uastParent as? UClass
+            ?: return false
+
+        return !psiClass.hasModifier(JvmModifier.ABSTRACT) &&
+            psiClass.findAnnotation(VelocityConstants.PLUGIN_ANNOTATION) != null
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -68,8 +68,8 @@
         <codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.demonwav.mcdev.insight.PluginLineMarkerProvider"/>
 
         <!-- Project-independent Annotators-->
-        <annotator language="JAVA" implementationClass="com.demonwav.mcdev.insight.ListenerEventAnnotator"/>
-        <annotator language="JAVA" implementationClass="com.demonwav.mcdev.insight.ColorAnnotator"/>
+        <annotator language="UAST" implementationClass="com.demonwav.mcdev.insight.ListenerEventAnnotator"/>
+        <annotator language="UAST" implementationClass="com.demonwav.mcdev.insight.ColorAnnotator"/>
 
         <!-- Project-independent Inspection Suppressors -->
         <lang.inspectionSuppressor language="JAVA" implementationClass="com.demonwav.mcdev.inspection.StaticListenerInspectionSuppressor"/>
@@ -176,7 +176,7 @@
         <implicitUsageProvider implementation="com.demonwav.mcdev.platform.sponge.insight.SpongeImplicitUsageProvider" />
 
         <!-- Sponge Annotator -->
-        <annotator language="JAVA" implementationClass="com.demonwav.mcdev.platform.sponge.color.SpongeColorAnnotator"/>
+        <annotator language="UAST" implementationClass="com.demonwav.mcdev.platform.sponge.color.SpongeColorAnnotator"/>
 
         <completion.contributor language="JAVA" implementationClass="com.demonwav.mcdev.platform.sponge.completion.SpongeGetterFilterCompletionContributor" />
         <psi.referenceContributor language="JAVA" implementation="com.demonwav.mcdev.platform.sponge.reference.SpongeReferenceContributor" />

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -65,7 +65,7 @@
         <!-- Project-independent Line Marker Providers -->
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.ListenerLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.ColorLineMarkerProvider"/>
-        <codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.demonwav.mcdev.insight.PluginLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.PluginLineMarkerProvider"/>
 
         <!-- Project-independent Annotators-->
         <annotator language="UAST" implementationClass="com.demonwav.mcdev.insight.ListenerEventAnnotator"/>


### PR DESCRIPTION
Namely:
- color line markers & annotator
- event listener line marker & annotators
- plugin line markers

I target 2020.3 because it has the most complete UAST implementation for all major JVM language plugins; I ran into some major issues with previous versions (some even affected Java code.)

I encountered a few minor problems so far:
* Annotations & color line markers do not work in Groovy, but are fine in Java, Kotlin and Scala. I suspect this is a bug in the Groovy plugin and given the language is not really used in modding AFAIK I will ignore this problem.

* The Scala plugin doesn't provide a `UastCodeGenerationPlugin` so we can't replace color constants. Vector-based Sponge `Color`s do not work either because of an NPE in their PsiElementFactory.