### PR TITLE
Small addition and fix in Mixin Module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     grammarKit("org.jetbrains.idea:grammar-kit:1.5.1")
 
     testLibs("org.jetbrains.idea:mockJDK:1.7-4d76c50")
-    testLibs("org.spongepowered:mixin:0.7-SNAPSHOT:thin")
+    testLibs("org.spongepowered:mixin:0.7-SNAPSHOT")
     testLibs("com.demonwav.mcdev:all-types-nbt:1.0@nbt")
     testLibs("org.spongepowered:spongeapi:7.0.0:shaded")
 

--- a/src/main/kotlin/platform/mixin/inspection/injector/InjectorType.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InjectorType.kt
@@ -13,9 +13,9 @@ package com.demonwav.mcdev.platform.mixin.inspection.injector
 import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants
 import com.demonwav.mcdev.platform.mixin.util.MixinMemberReference
+import com.demonwav.mcdev.platform.mixin.util.argsType
 import com.demonwav.mcdev.platform.mixin.util.callbackInfoReturnableType
 import com.demonwav.mcdev.platform.mixin.util.callbackInfoType
-import com.demonwav.mcdev.platform.mixin.util.argsType
 import com.demonwav.mcdev.util.Parameter
 import com.demonwav.mcdev.util.constantStringValue
 import com.demonwav.mcdev.util.constantValue
@@ -78,9 +78,9 @@ enum class InjectorType(private val annotation: String) {
             // Right now we allow any parameters here since we can't easily
             // detect the local variables that can be captured
             if ((
-                        (annotation.findDeclaredAttributeValue("locals") as? PsiQualifiedReference)
-                            ?.referenceName ?: "NO_CAPTURE"
-                        ) != "NO_CAPTURE"
+                (annotation.findDeclaredAttributeValue("locals") as? PsiQualifiedReference)
+                    ?.referenceName ?: "NO_CAPTURE"
+                ) != "NO_CAPTURE"
             ) {
                 result.add(ParameterGroup(null))
             }

--- a/src/main/kotlin/platform/mixin/inspection/injector/InjectorType.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InjectorType.kt
@@ -15,6 +15,7 @@ import com.demonwav.mcdev.platform.mixin.util.MixinConstants
 import com.demonwav.mcdev.platform.mixin.util.MixinMemberReference
 import com.demonwav.mcdev.platform.mixin.util.callbackInfoReturnableType
 import com.demonwav.mcdev.platform.mixin.util.callbackInfoType
+import com.demonwav.mcdev.platform.mixin.util.argsType
 import com.demonwav.mcdev.util.Parameter
 import com.demonwav.mcdev.util.constantStringValue
 import com.demonwav.mcdev.util.constantValue
@@ -41,18 +42,21 @@ enum class InjectorType(private val annotation: String) {
 
             val result = ArrayList<ParameterGroup>()
 
+            val targetMethodParameters = mutableListOf<Parameter>()
+
             if (targetMethod.isConstructor) {
                 val containingClass = targetMethod.containingClass
                 val outerClass = containingClass?.containingClass
                 if (outerClass != null && !containingClass.hasModifier(JvmModifier.STATIC)) {
                     val outerClassType = JavaPsiFacade.getElementFactory(outerClass.project).createType(outerClass)
-                    // Inner classes ctors take their outer class as first parameter (required)
-                    result.add(ParameterGroup(listOf(Parameter("outer", outerClassType))))
+                    // Inner classes ctors take their outer class as first parameter
+                    targetMethodParameters.add(Parameter("outer", outerClassType))
                 }
             }
 
             // Parameters from injected method (optional)
-            result.add(ParameterGroup(collectTargetMethodParameters(targetMethod), required = false, default = true))
+            targetMethodParameters.addAll(collectTargetMethodParameters(targetMethod))
+            result.add(ParameterGroup(targetMethodParameters, required = false, default = true))
 
             // Callback info (required)
             result.add(
@@ -74,9 +78,9 @@ enum class InjectorType(private val annotation: String) {
             // Right now we allow any parameters here since we can't easily
             // detect the local variables that can be captured
             if ((
-                (annotation.findDeclaredAttributeValue("locals") as? PsiQualifiedReference)
-                    ?.referenceName ?: "NO_CAPTURE"
-                ) != "NO_CAPTURE"
+                        (annotation.findDeclaredAttributeValue("locals") as? PsiQualifiedReference)
+                            ?.referenceName ?: "NO_CAPTURE"
+                        ) != "NO_CAPTURE"
             ) {
                 result.add(ParameterGroup(null))
             }
@@ -173,6 +177,19 @@ enum class InjectorType(private val annotation: String) {
         }
     },
     MODIFY_ARG(MixinConstants.Annotations.MODIFY_ARG),
+    MODIFY_ARGS(MixinConstants.Annotations.MODIFY_ARGS) {
+        override fun expectedMethodSignature(annotation: PsiAnnotation, targetMethod: PsiMethod): MethodSignature? {
+            val result = ArrayList<ParameterGroup>()
+
+            // Args object (required)
+            result.add(ParameterGroup(listOf(Parameter("args", argsType(annotation.project)))))
+
+            // Parameters from injected method (optional)
+            result.add(ParameterGroup(collectTargetMethodParameters(targetMethod), required = false))
+
+            return MethodSignature(result, PsiType.VOID)
+        }
+    },
     MODIFY_CONSTANT(MixinConstants.Annotations.MODIFY_CONSTANT),
     MODIFY_VARIABLE(MixinConstants.Annotations.MODIFY_VARIABLE);
 

--- a/src/main/kotlin/platform/mixin/util/Mixin.kt
+++ b/src/main/kotlin/platform/mixin/util/Mixin.kt
@@ -13,9 +13,9 @@ package com.demonwav.mcdev.platform.mixin.util
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.ACCESSOR
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.INVOKER
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MIXIN
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.ARGS
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO_RETURNABLE
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.ARGS
 import com.demonwav.mcdev.util.cached
 import com.demonwav.mcdev.util.computeStringArray
 import com.demonwav.mcdev.util.findQualifiedClass

--- a/src/main/kotlin/platform/mixin/util/Mixin.kt
+++ b/src/main/kotlin/platform/mixin/util/Mixin.kt
@@ -15,6 +15,7 @@ import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.INVOKER
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MIXIN
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO_RETURNABLE
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.ARGS
 import com.demonwav.mcdev.util.cached
 import com.demonwav.mcdev.util.computeStringArray
 import com.demonwav.mcdev.util.findQualifiedClass
@@ -115,3 +116,6 @@ fun callbackInfoReturnableType(project: Project, context: PsiElement, returnType
             ?: return null
     return JavaPsiFacade.getElementFactory(project).createType(psiClass, boxedType)
 }
+
+fun argsType(project: Project): PsiType =
+    PsiType.getTypeByName(ARGS, project, GlobalSearchScope.allScope(project))

--- a/src/main/kotlin/platform/mixin/util/MixinConstants.kt
+++ b/src/main/kotlin/platform/mixin/util/MixinConstants.kt
@@ -19,6 +19,7 @@ object MixinConstants {
     object Classes {
         const val CALLBACK_INFO = "org.spongepowered.asm.mixin.injection.callback.CallbackInfo"
         const val CALLBACK_INFO_RETURNABLE = "org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable"
+        const val ARGS = "org.spongepowered.asm.mixin.injection.invoke.arg.Args"
         const val COMPATIBILITY_LEVEL = "org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel"
         const val INJECTION_POINT = "org.spongepowered.asm.mixin.injection.InjectionPoint"
         const val MIXIN_AGENT = "org.spongepowered.tools.agent.MixinAgent"

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
@@ -33,7 +33,7 @@ class InvalidInjectorMethodSignatureFixTest : BaseMixinTest() {
 
                     class MixedInSimple {
                         public void simpleMethod(String string, int i) {
-                            int i = Integer.parseInt("FF", 16);
+                            int testInt = Integer.parseInt("FF", 16);
                         }
                     }
                     """,

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
@@ -33,6 +33,7 @@ class InvalidInjectorMethodSignatureFixTest : BaseMixinTest() {
 
                     class MixedInSimple {
                         public void simpleMethod(String string, int i) {
+                            int i = Integer.parseInt("FF", 16);
                         }
                     }
                     """,
@@ -83,4 +84,8 @@ class InvalidInjectorMethodSignatureFixTest : BaseMixinTest() {
     @Test
     @DisplayName("Inject without CallbackInfo")
     fun injectWithoutCI() = doTest("injectWithoutCI")
+
+    @Test
+    @DisplayName("ModifyArgs")
+    fun modifyArgs() = doTest("modifyArgs")
 }

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureInspectionTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureInspectionTest.kt
@@ -74,12 +74,12 @@ class InvalidInjectorMethodSignatureInspectionTest : BaseMixinTest() {
             @Mixin(MixedInOuter.MixedInInner.class)
             public class TestMixin {
 
-                @Inject(method = "<init>", at = @At("RETURN"))
+                @Inject(method = "<init>()V", at = @At("RETURN"))
                 private void injectCtor(MixedInOuter outer, CallbackInfo ci) {
                 }
 
                 @Inject(method = "<init>", at = @At("RETURN"))
-                private void injectCtor<error descr="Method parameters do not match expected parameters for @Inject">(CallbackInfo ci)</error> {
+                private void injectCtor(CallbackInfo ci) {
                 }
 
                 @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/innerCtorWithLocals.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/innerCtorWithLocals.java
@@ -9,6 +9,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class TestMixin {
 
     @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))
-    private void injectCtor(CallbackInfo ci<caret>, String local1, float local2, int local3) {
+    private void injectCtor(String string, CallbackInfo ci<caret>, String local1, float local2, int local3) {
     }
 }

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/modifyArgs.after.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/modifyArgs.after.java
@@ -1,0 +1,15 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @ModifyArgs(method = "simpleMethod", at = @At(value = "INVOKE", target = "Ljava/lang/Integer;parseInt(Ljava/lang/String;I)I"))
+    private void inject(Args args<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/modifyArgs.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/modifyArgs.java
@@ -1,0 +1,15 @@
+package test;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @ModifyArgs(method = "simpleMethod", at = @At(value = "INVOKE", target = "Ljava/lang/Integer;parseInt(Ljava/lang/String;I)I"))
+    private void inject(String stringToParse, int base<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleInnerCtor.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleInnerCtor.java
@@ -9,6 +9,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class TestMixin {
 
     @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))
-    private void injectCtor(CallbackInfo ci<caret>) {
+    private void injectCtor(String string, CallbackInfo ci<caret>) {
     }
 }


### PR DESCRIPTION
Adds parameter and return type checking for @ModifyArgs
Resolves outer class constructor param being required; it is now treated as part of the method's optional parameters