### PR TITLE
Support new Bungeecord versioning scheme

### DIFF
--- a/src/main/kotlin/platform/PlatformType.kt
+++ b/src/main/kotlin/platform/PlatformType.kt
@@ -51,7 +51,7 @@ enum class PlatformType(
     FORGE(ForgeModuleType, "Forge"),
     FABRIC(FabricModuleType, "Fabric"),
     SPONGE(SpongeModuleType, "Sponge"),
-    BUNGEECORD(BungeeCordModuleType, "BungeeCord", "bungeecord.json"),
+    BUNGEECORD(BungeeCordModuleType, "BungeeCord", "bungeecord_v2.json"),
     WATERFALL(WaterfallModuleType, "Waterfall", "waterfall.json", BUNGEECORD),
     VELOCITY(VelocityModuleType, "Velocity", "velocity.json"),
     LITELOADER(LiteLoaderModuleType, "LiteLoader"),

--- a/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectCreator.kt
+++ b/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectCreator.kt
@@ -171,7 +171,7 @@ class BungeeCordDependenciesStep(
                     BuildDependency(
                         "net.md-5",
                         "bungeecord-api",
-                        "$mcVersion-SNAPSHOT",
+                        mcVersion,
                         mavenScope = "provided",
                         gradleConfiguration = "compileOnly"
                     )

--- a/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectSettingsWizard.form
+++ b/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectSettingsWizard.form
@@ -90,7 +90,7 @@
                       <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
-                      <text value="Minecraft Version"/>
+                      <text value="Version"/>
                     </properties>
                   </component>
                   <component id="234c0" class="javax.swing.JLabel" binding="errorLabel">


### PR DESCRIPTION
To be merged with https://github.com/minecraft-dev/minecraftdev.org/pull/13

Bungeecord now have "real" releases, they publish snapshots for the next release, and they drop snapshots of published releases.
Last time I checked Waterfall only publishes snapshots, meaning its project creator is not affected (only the versions JSON on the website needs to be updated.)

Fixes #799 