### PR TITLE
Force UTF-8 in processResource task

### DIFF
--- a/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit Submodule build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit Submodule build.gradle.ft
@@ -10,6 +10,7 @@ dependencies {
 }
 
 processResources {
+    filteringCharset = 'UTF-8'
     from(sourceSets.main.resources.srcDirs) {
         expand 'version': project.version
     }

--- a/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit build.gradle.ft
@@ -18,6 +18,7 @@ dependencies {
 }
 
 processResources {
+    filteringCharset = 'UTF-8'
     from(sourceSets.main.resources.srcDirs) {
         filter ReplaceTokens, tokens: [version: version]
     }

--- a/src/main/resources/fileTemplates/j2ee/bungeecord/BungeeCord Submodule build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/bungeecord/BungeeCord Submodule build.gradle.ft
@@ -8,6 +8,7 @@ dependencies {
 }
 
 processResources {
+    filteringCharset = 'UTF-8'
     from(sourceSets.main.resources.srcDirs) {
         expand 'version': project.version
     }

--- a/src/main/resources/fileTemplates/j2ee/bungeecord/BungeeCord build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/bungeecord/BungeeCord build.gradle.ft
@@ -16,6 +16,7 @@ dependencies {
 }
 
 processResources {
+    filteringCharset = 'UTF-8'
     from(sourceSets.main.resources.srcDirs) {
         filter ReplaceTokens, tokens: [version: version]
     }

--- a/src/main/resources/fileTemplates/j2ee/fabric/fabric_build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/fabric/fabric_build.gradle.ft
@@ -26,6 +26,7 @@ dependencies {
 }
 
 processResources {
+    filteringCharset = 'UTF-8'
     inputs.property "version", project.version
 
     from(sourceSets.main.resources.srcDirs) {

--- a/src/main/resources/fileTemplates/j2ee/forge/Forge build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/forge/Forge build.gradle.ft
@@ -38,6 +38,7 @@ dependencies {
 }
 
 processResources {
+    filteringCharset = 'UTF-8'
     // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version


### PR DESCRIPTION
processResource task uses Windows system encoding(which isn't UTF-8 by default).
People who use other than English might get confused about why their plugins/mods not being loaded properly.
This PR forces UTF-8 in processResource task