### PR TITLE
Fix AT generation for members in subclasses

### DIFF
--- a/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
+++ b/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
@@ -25,9 +25,11 @@ class CopyAtAction : SrgActionBase() {
     override fun withSrgTarget(parent: PsiElement, srgMap: McpSrgMap, e: AnActionEvent, data: ActionData) {
         when (parent) {
             is PsiField -> {
-                if (parent.containingClass == null)
+                if (parent.containingClass == null) {
                     return showBalloon("No SRG name found", e)
-                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon("No SRG name found", e)
+                }
+                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon(
+                    "No SRG name found", e)
                 val srg = srgMap.getSrgField(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,
@@ -36,9 +38,11 @@ class CopyAtAction : SrgActionBase() {
                 )
             }
             is PsiMethod -> {
-                if (parent.containingClass == null)
+                if (parent.containingClass == null) {
                     return showBalloon("No SRG name found", e)
-                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon("No SRG name found", e)
+                }
+                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon(
+                    "No SRG name found", e)
                 val srg = srgMap.getSrgMethod(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,

--- a/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
+++ b/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
@@ -25,13 +25,8 @@ class CopyAtAction : SrgActionBase() {
     override fun withSrgTarget(parent: PsiElement, srgMap: McpSrgMap, e: AnActionEvent, data: ActionData) {
         when (parent) {
             is PsiField -> {
-                if (parent.containingClass == null) {
-                    return showBalloon("No SRG name found", e)
-                }
-                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon(
-                    "No SRG name found",
-                    e
-                )
+                val containing = parent.containingClass ?: return showBalloon("No SRG name found", e)
+                val classSrg = srgMap.getSrgClass(containing) ?: return showBalloon("No SRG name found", e)
                 val srg = srgMap.getSrgField(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,
@@ -40,13 +35,8 @@ class CopyAtAction : SrgActionBase() {
                 )
             }
             is PsiMethod -> {
-                if (parent.containingClass == null) {
-                    return showBalloon("No SRG name found", e)
-                }
-                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon(
-                    "No SRG name found",
-                    e
-                )
+                val containing = parent.containingClass ?: return showBalloon("No SRG name found", e)
+                val classSrg = srgMap.getSrgClass(containing) ?: return showBalloon("No SRG name found", e)
                 val srg = srgMap.getSrgMethod(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,

--- a/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
+++ b/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
@@ -25,19 +25,25 @@ class CopyAtAction : SrgActionBase() {
     override fun withSrgTarget(parent: PsiElement, srgMap: McpSrgMap, e: AnActionEvent, data: ActionData) {
         when (parent) {
             is PsiField -> {
+                if (parent.containingClass == null)
+                    return showBalloon("No SRG name found", e)
+                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon("No SRG name found", e)
                 val srg = srgMap.getSrgField(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,
                     data.element,
-                    parent.containingClass?.qualifiedName + " " + srg.name + " # " + parent.name
+                    classSrg + " " + srg.name + " # " + parent.name
                 )
             }
             is PsiMethod -> {
+                if (parent.containingClass == null)
+                    return showBalloon("No SRG name found", e)
+                val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon("No SRG name found", e)
                 val srg = srgMap.getSrgMethod(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,
                     data.element,
-                    parent.containingClass?.qualifiedName + " " + srg.name + srg.descriptor + " # " + parent.name
+                    classSrg + " " + srg.name + srg.descriptor + " # " + parent.name
                 )
             }
             is PsiClass -> {

--- a/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
+++ b/src/main/kotlin/platform/mcp/actions/CopyAtAction.kt
@@ -29,7 +29,9 @@ class CopyAtAction : SrgActionBase() {
                     return showBalloon("No SRG name found", e)
                 }
                 val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon(
-                    "No SRG name found", e)
+                    "No SRG name found",
+                    e
+                )
                 val srg = srgMap.getSrgField(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,
@@ -42,7 +44,9 @@ class CopyAtAction : SrgActionBase() {
                     return showBalloon("No SRG name found", e)
                 }
                 val classSrg = srgMap.getSrgClass(parent.containingClass!!) ?: return showBalloon(
-                    "No SRG name found", e)
+                    "No SRG name found",
+                    e
+                )
                 val srg = srgMap.getSrgMethod(parent) ?: return showBalloon("No SRG name found", e)
                 copyToClipboard(
                     data.editor,


### PR DESCRIPTION
Currently, ATs generated by this plugin are invalid if the field or method is inside of a subclass. This fixes the problem and correctly generates AT entries. (Tested and works)