### PR TITLE
Sponge 8 templates

### DIFF
--- a/src/main/kotlin/creator/buildsystem/gradle/gradle-steps.kt
+++ b/src/main/kotlin/creator/buildsystem/gradle/gradle-steps.kt
@@ -147,7 +147,12 @@ fun setupGradleFiles(dir: Path, givenFiles: GradleFiles<String>, kotlinScript: B
     }
 }
 
-fun addBuildGradleDependencies(project: Project, buildSystem: BuildSystem, text: String, kotlinScript: Boolean = false): PsiFile {
+fun addBuildGradleDependencies(
+    project: Project,
+    buildSystem: BuildSystem,
+    text: String,
+    kotlinScript: Boolean = false
+): PsiFile {
     val file = PsiFileFactory.getInstance(project).createFileFromText(GroovyLanguage, text)
     return file.runWriteAction {
         val fileName = if (kotlinScript) "build.gradle.kts" else "build.gradle"

--- a/src/main/kotlin/creator/buildsystem/gradle/gradle-steps.kt
+++ b/src/main/kotlin/creator/buildsystem/gradle/gradle-steps.kt
@@ -219,7 +219,8 @@ private fun getClosableBlockByName(element: PsiElement, name: String) =
 class BasicGradleFinalizerStep(
     private val module: Module,
     private val rootDirectory: Path,
-    private val buildSystem: BuildSystem
+    private val buildSystem: BuildSystem,
+    private vararg val additionalRunTasks: String
 ) : CreatorStep {
     private val project
         get() = module.project
@@ -238,10 +239,17 @@ class BasicGradleFinalizerStep(
 
         // Set up the run config
         // Get the gradle external task type, this is what sets it as a gradle task
+        addRunTaskConfiguration("build")
+        for (tasks in additionalRunTasks) {
+            addRunTaskConfiguration(tasks)
+        }
+    }
+
+    private fun addRunTaskConfiguration(task: String) {
         val gradleType = GradleExternalTaskConfigurationType.getInstance()
 
         val runManager = RunManager.getInstance(project)
-        val runConfigName = buildSystem.artifactId + " build"
+        val runConfigName = buildSystem.artifactId + ' ' + task
 
         val runConfiguration = ExternalSystemRunConfiguration(
             GradleConstants.SYSTEM_ID,
@@ -253,7 +261,7 @@ class BasicGradleFinalizerStep(
         // Set relevant gradle values
         runConfiguration.settings.externalProjectPath = rootDirectory.toAbsolutePath().toString()
         runConfiguration.settings.executionName = runConfigName
-        runConfiguration.settings.taskNames = listOf("build")
+        runConfiguration.settings.taskNames = listOf(task)
 
         runConfiguration.isAllowRunningInParallel = false
 

--- a/src/main/kotlin/platform/BaseTemplate.kt
+++ b/src/main/kotlin/platform/BaseTemplate.kt
@@ -17,12 +17,12 @@ abstract class BaseTemplate {
 
     protected fun Project.applyTemplate(
         templateName: String,
-        properties: Map<String, String>? = null
+        properties: Map<String, *>? = null
     ): String {
         val manager = FileTemplateManager.getInstance(this)
         val template = manager.getJ2eeTemplate(templateName)
 
-        val allProperties = manager.defaultProperties
+        val allProperties = manager.defaultProperties.toMutableMap()
         properties?.let { prop -> allProperties.putAll(prop) }
 
         return template.getText(allProperties)

--- a/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
@@ -69,17 +69,25 @@ class Sponge8GradleCreator(
     }
 
     override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        TODO()
-        // val mainClassStep = setupMainClassStep()
-        //
-        // val buildText = SpongeTemplate.applySubBuildGradle(project, buildSystem)
-        // val files = GradleFiles(buildText, null, null)
-        //
-        // return listOf(
-        //     setupDependencyStep(),
-        //     CreateDirectoriesStep(buildSystem, rootDirectory),
-        //     GradleSetupStep(project, rootDirectory, buildSystem, files),
-        //     mainClassStep
-        // )
+        val mainClassStep = setupMainClassStep()
+
+        val buildText = Sponge8Template.applySubBuildGradle(
+            project,
+            buildSystem,
+            config.spongeApiVersion,
+            config.pluginName,
+            config.mainClass,
+            config.description,
+            config.website,
+            config.authors,
+            config.dependencies
+        )
+        val files = GradleFiles(buildText, null, null)
+
+        return listOf(
+            CreateDirectoriesStep(buildSystem, rootDirectory),
+            GradleSetupStep(project, rootDirectory, buildSystem, files, true),
+            mainClassStep
+        )
     }
 }

--- a/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
@@ -107,13 +107,7 @@ class Sponge8GradleCreator(
         val buildText = Sponge8Template.applyBuildGradle(
             project,
             buildSystem,
-            config.spongeApiVersion,
-            config.pluginName,
-            config.mainClass,
-            config.description,
-            config.website,
-            config.authors,
-            config.dependencies
+            config
         )
         val propText = Sponge8Template.applyGradleProp(project)
         val settingsText = Sponge8Template.applySettingsGradle(project, buildSystem.artifactId)
@@ -135,13 +129,7 @@ class Sponge8GradleCreator(
         val buildText = Sponge8Template.applySubBuildGradle(
             project,
             buildSystem,
-            config.spongeApiVersion,
-            config.pluginName,
-            config.mainClass,
-            config.description,
-            config.website,
-            config.authors,
-            config.dependencies
+            config
         )
         val files = GradleFiles(buildText, null, null)
 

--- a/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
@@ -1,0 +1,85 @@
+package com.demonwav.mcdev.platform.sponge.creator
+
+import com.demonwav.mcdev.creator.BaseProjectCreator
+import com.demonwav.mcdev.creator.BasicJavaClassStep
+import com.demonwav.mcdev.creator.CreateDirectoriesStep
+import com.demonwav.mcdev.creator.CreatorStep
+import com.demonwav.mcdev.creator.buildsystem.BuildSystem
+import com.demonwav.mcdev.creator.buildsystem.gradle.BasicGradleFinalizerStep
+import com.demonwav.mcdev.creator.buildsystem.gradle.GradleBuildSystem
+import com.demonwav.mcdev.creator.buildsystem.gradle.GradleFiles
+import com.demonwav.mcdev.creator.buildsystem.gradle.GradleGitignoreStep
+import com.demonwav.mcdev.creator.buildsystem.gradle.GradleSetupStep
+import com.demonwav.mcdev.creator.buildsystem.gradle.GradleWrapperStep
+import com.intellij.openapi.module.Module
+import java.nio.file.Path
+
+sealed class Sponge8ProjectCreator<T : BuildSystem>(
+    protected val rootDirectory: Path,
+    protected val rootModule: Module,
+    protected val buildSystem: T,
+    protected val config: SpongeProjectConfig
+) : BaseProjectCreator(rootModule, buildSystem) {
+
+    protected fun setupDependencyStep(): SpongeDependenciesSetup {
+        val spongeApiVersion = config.spongeApiVersion
+        return SpongeDependenciesSetup(buildSystem, spongeApiVersion)
+    }
+
+    protected fun setupMainClassStep(): BasicJavaClassStep {
+        return createJavaClassStep(config.mainClass) { packageName, className ->
+            Sponge8Template.applyMainClass(project, buildSystem.artifactId, packageName, className)
+        }
+    }
+}
+
+class Sponge8GradleCreator(
+    rootDirectory: Path,
+    rootModule: Module,
+    buildSystem: GradleBuildSystem,
+    config: SpongeProjectConfig
+) : Sponge8ProjectCreator<GradleBuildSystem>(rootDirectory, rootModule, buildSystem, config) {
+
+    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+        val mainClassStep = setupMainClassStep()
+
+        val buildText = Sponge8Template.applyBuildGradle(
+            project,
+            buildSystem,
+            config.spongeApiVersion,
+            config.pluginName,
+            config.mainClass,
+            config.description,
+            config.website,
+            config.authors,
+            config.dependencies
+        )
+        val propText = Sponge8Template.applyGradleProp(project)
+        val settingsText = Sponge8Template.applySettingsGradle(project, buildSystem.artifactId)
+        val files = GradleFiles(buildText, propText, settingsText)
+
+        return listOf(
+            CreateDirectoriesStep(buildSystem, rootDirectory),
+            GradleSetupStep(project, rootDirectory, buildSystem, files, true),
+            mainClassStep,
+            GradleWrapperStep(project, rootDirectory, buildSystem),
+            GradleGitignoreStep(project, rootDirectory),
+            BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem)
+        )
+    }
+
+    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
+        TODO()
+        // val mainClassStep = setupMainClassStep()
+        //
+        // val buildText = SpongeTemplate.applySubBuildGradle(project, buildSystem)
+        // val files = GradleFiles(buildText, null, null)
+        //
+        // return listOf(
+        //     setupDependencyStep(),
+        //     CreateDirectoriesStep(buildSystem, rootDirectory),
+        //     GradleSetupStep(project, rootDirectory, buildSystem, files),
+        //     mainClassStep
+        // )
+    }
+}

--- a/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
@@ -1,3 +1,13 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
 package com.demonwav.mcdev.platform.sponge.creator
 
 import com.demonwav.mcdev.creator.BaseProjectCreator

--- a/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
@@ -125,7 +125,7 @@ class Sponge8GradleCreator(
             mainClassStep,
             GradleWrapperStep(project, rootDirectory, buildSystem),
             GradleGitignoreStep(project, rootDirectory),
-            BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem)
+            BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem, "runServer")
         )
     }
 

--- a/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
@@ -16,6 +16,7 @@ import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_BUILD_GRADLE
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_GRADLE_PROPERTIES_TEMPLATE
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_MAIN_CLASS_TEMPLATE
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_SETTINGS_GRADLE_TEMPLATE
+import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE
 import com.intellij.openapi.project.Project
 
 object Sponge8Template : BaseTemplate() {
@@ -82,12 +83,31 @@ object Sponge8Template : BaseTemplate() {
         return project.applyTemplate(SPONGE8_SETTINGS_GRADLE_TEMPLATE, props)
     }
 
-    // fun applySubBuildGradle(project: Project, buildSystem: BuildSystem): String {
-    //     val props = mapOf(
-    //         "COMMON_PROJECT_NAME" to buildSystem.commonModuleName,
-    //         "PLUGIN_ID" to buildSystem.artifactId
-    //     )
-    //
-    //     return project.applyTemplate(SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE, props)
-    // }
+    fun applySubBuildGradle(
+        project: Project,
+        buildSystem: BuildSystem,
+        spongeApiVersion: String,
+        pluginName: String,
+        mainClass: String,
+        description: String?,
+        website: String?,
+        authors: List<String>,
+        dependencies: List<String>
+    ): String {
+        val props = mutableMapOf(
+            "GROUP_ID" to buildSystem.groupId,
+            "PLUGIN_ID" to buildSystem.artifactId,
+            "PLUGIN_VERSION" to buildSystem.version,
+            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"), // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
+            "PLUGIN_NAME" to pluginName,
+            "MAIN_CLASS" to mainClass,
+            "DESCRIPTION" to description,
+            "WEBSITE" to website,
+            "AUTHORS" to authors,
+            "DEPENDENCIES" to dependencies,
+            "COMMON_PROJECT_NAME" to buildSystem.commonModuleName
+        )
+
+        return project.applyTemplate(SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE, props)
+    }
 }

--- a/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
@@ -21,14 +21,6 @@ import com.intellij.openapi.project.Project
 
 object Sponge8Template : BaseTemplate() {
 
-    // fun applyPom(project: Project): String {
-    //     return project.applyTemplate(SPONGE8_POM_TEMPLATE, BasicMavenStep.pluginVersions)
-    // }
-    //
-    // fun applySubPom(project: Project): String {
-    //     return project.applyTemplate(SPONGE8_SUBMODULE_POM_TEMPLATE, BasicMavenStep.pluginVersions)
-    // }
-
     fun applyMainClass(
         project: Project,
         pluginId: String,
@@ -95,9 +87,7 @@ object Sponge8Template : BaseTemplate() {
         dependencies: List<String>
     ): String {
         val props = mutableMapOf(
-            "GROUP_ID" to buildSystem.groupId,
-            "PLUGIN_ID" to buildSystem.artifactId,
-            "PLUGIN_VERSION" to buildSystem.version,
+            "PLUGIN_ID" to buildSystem.parentOrError.artifactId,
             "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"), // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
             "PLUGIN_NAME" to pluginName,
             "MAIN_CLASS" to mainClass,

--- a/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
@@ -39,26 +39,20 @@ object Sponge8Template : BaseTemplate() {
     fun applyBuildGradle(
         project: Project,
         buildSystem: BuildSystem,
-        spongeApiVersion: String,
-        pluginName: String,
-        mainClass: String,
-        description: String?,
-        website: String?,
-        authors: List<String>,
-        dependencies: List<String>
+        config: SpongeProjectConfig
     ): String {
         val props = mutableMapOf(
             "GROUP_ID" to buildSystem.groupId,
             "PLUGIN_ID" to buildSystem.artifactId,
             "PLUGIN_VERSION" to buildSystem.version,
             // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
-            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"),
-            "PLUGIN_NAME" to pluginName,
-            "MAIN_CLASS" to mainClass,
-            "DESCRIPTION" to description,
-            "WEBSITE" to website,
-            "AUTHORS" to authors,
-            "DEPENDENCIES" to dependencies
+            "SPONGEAPI_VERSION" to config.spongeApiVersion.removeSuffix("-SNAPSHOT"),
+            "PLUGIN_NAME" to config.pluginName,
+            "MAIN_CLASS" to config.mainClass,
+            "DESCRIPTION" to config.description,
+            "WEBSITE" to config.website,
+            "AUTHORS" to config.authors,
+            "DEPENDENCIES" to config.dependencies
         )
 
         return project.applyTemplate(SPONGE8_BUILD_GRADLE_TEMPLATE, props)
@@ -79,24 +73,18 @@ object Sponge8Template : BaseTemplate() {
     fun applySubBuildGradle(
         project: Project,
         buildSystem: BuildSystem,
-        spongeApiVersion: String,
-        pluginName: String,
-        mainClass: String,
-        description: String?,
-        website: String?,
-        authors: List<String>,
-        dependencies: List<String>
+        config: SpongeProjectConfig
     ): String {
         val props = mutableMapOf(
             "PLUGIN_ID" to buildSystem.parentOrError.artifactId,
             // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
-            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"),
-            "PLUGIN_NAME" to pluginName,
-            "MAIN_CLASS" to mainClass,
-            "DESCRIPTION" to description,
-            "WEBSITE" to website,
-            "AUTHORS" to authors,
-            "DEPENDENCIES" to dependencies,
+            "SPONGEAPI_VERSION" to config.spongeApiVersion.removeSuffix("-SNAPSHOT"),
+            "PLUGIN_NAME" to config.pluginName,
+            "MAIN_CLASS" to config.mainClass,
+            "DESCRIPTION" to config.description,
+            "WEBSITE" to config.website,
+            "AUTHORS" to config.authors,
+            "DEPENDENCIES" to config.dependencies,
             "COMMON_PROJECT_NAME" to buildSystem.commonModuleName
         )
 

--- a/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
@@ -15,6 +15,7 @@ import com.demonwav.mcdev.platform.BaseTemplate
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_BUILD_GRADLE_TEMPLATE
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_GRADLE_PROPERTIES_TEMPLATE
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_MAIN_CLASS_TEMPLATE
+import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_PLUGINS_JSON_TEMPLATE
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_SETTINGS_GRADLE_TEMPLATE
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE
 import com.intellij.openapi.project.Project
@@ -34,6 +35,26 @@ object Sponge8Template : BaseTemplate() {
         )
 
         return project.applyTemplate(SPONGE8_MAIN_CLASS_TEMPLATE, props)
+    }
+
+    fun applyPluginsJson(
+        project: Project,
+        buildSystem: BuildSystem,
+        config: SpongeProjectConfig
+    ): String {
+        val props = mutableMapOf(
+            "PLUGIN_ID" to buildSystem.artifactId,
+            "VERSION_PLACEHOLDER" to "\${version}",
+            "SPONGEAPI_VERSION" to config.spongeApiVersion,
+            "PLUGIN_NAME" to config.pluginName,
+            "MAIN_CLASS" to config.mainClass,
+            "DESCRIPTION" to config.description,
+            "WEBSITE" to config.website,
+            "AUTHORS" to config.authors,
+            "DEPENDENCIES" to config.dependencies
+        )
+
+        return project.applyTemplate(SPONGE8_PLUGINS_JSON_TEMPLATE, props)
     }
 
     fun applyBuildGradle(

--- a/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
@@ -51,7 +51,8 @@ object Sponge8Template : BaseTemplate() {
             "GROUP_ID" to buildSystem.groupId,
             "PLUGIN_ID" to buildSystem.artifactId,
             "PLUGIN_VERSION" to buildSystem.version,
-            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"), // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
+            // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
+            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"),
             "PLUGIN_NAME" to pluginName,
             "MAIN_CLASS" to mainClass,
             "DESCRIPTION" to description,
@@ -88,7 +89,8 @@ object Sponge8Template : BaseTemplate() {
     ): String {
         val props = mutableMapOf(
             "PLUGIN_ID" to buildSystem.parentOrError.artifactId,
-            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"), // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
+            // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
+            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"),
             "PLUGIN_NAME" to pluginName,
             "MAIN_CLASS" to mainClass,
             "DESCRIPTION" to description,

--- a/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8Template.kt
@@ -1,0 +1,93 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.sponge.creator
+
+import com.demonwav.mcdev.creator.buildsystem.BuildSystem
+import com.demonwav.mcdev.platform.BaseTemplate
+import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_BUILD_GRADLE_TEMPLATE
+import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_GRADLE_PROPERTIES_TEMPLATE
+import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_MAIN_CLASS_TEMPLATE
+import com.demonwav.mcdev.util.MinecraftTemplates.Companion.SPONGE8_SETTINGS_GRADLE_TEMPLATE
+import com.intellij.openapi.project.Project
+
+object Sponge8Template : BaseTemplate() {
+
+    // fun applyPom(project: Project): String {
+    //     return project.applyTemplate(SPONGE8_POM_TEMPLATE, BasicMavenStep.pluginVersions)
+    // }
+    //
+    // fun applySubPom(project: Project): String {
+    //     return project.applyTemplate(SPONGE8_SUBMODULE_POM_TEMPLATE, BasicMavenStep.pluginVersions)
+    // }
+
+    fun applyMainClass(
+        project: Project,
+        pluginId: String,
+        packageName: String,
+        className: String
+    ): String {
+        val props = mutableMapOf(
+            "PLUGIN_ID" to pluginId,
+            "PACKAGE" to packageName,
+            "CLASS_NAME" to className
+        )
+
+        return project.applyTemplate(SPONGE8_MAIN_CLASS_TEMPLATE, props)
+    }
+
+    fun applyBuildGradle(
+        project: Project,
+        buildSystem: BuildSystem,
+        spongeApiVersion: String,
+        pluginName: String,
+        mainClass: String,
+        description: String?,
+        website: String?,
+        authors: List<String>,
+        dependencies: List<String>
+    ): String {
+        val props = mutableMapOf(
+            "GROUP_ID" to buildSystem.groupId,
+            "PLUGIN_ID" to buildSystem.artifactId,
+            "PLUGIN_VERSION" to buildSystem.version,
+            "SPONGEAPI_VERSION" to spongeApiVersion.removeSuffix("-SNAPSHOT"), // SpongeGradle 1.1.0 adds the -SNAPSHOT suffix itself
+            "PLUGIN_NAME" to pluginName,
+            "MAIN_CLASS" to mainClass,
+            "DESCRIPTION" to description,
+            "WEBSITE" to website,
+            "AUTHORS" to authors,
+            "DEPENDENCIES" to dependencies
+        )
+
+        return project.applyTemplate(SPONGE8_BUILD_GRADLE_TEMPLATE, props)
+    }
+
+    fun applyGradleProp(project: Project): String {
+        return project.applyTemplate(SPONGE8_GRADLE_PROPERTIES_TEMPLATE)
+    }
+
+    fun applySettingsGradle(project: Project, artifactId: String): String {
+        val props = mapOf(
+            "ARTIFACT_ID" to artifactId
+        )
+
+        return project.applyTemplate(SPONGE8_SETTINGS_GRADLE_TEMPLATE, props)
+    }
+
+    // fun applySubBuildGradle(project: Project, buildSystem: BuildSystem): String {
+    //     val props = mapOf(
+    //         "COMMON_PROJECT_NAME" to buildSystem.commonModuleName,
+    //         "PLUGIN_ID" to buildSystem.artifactId
+    //     )
+    //
+    //     return project.applyTemplate(SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE, props)
+    // }
+}

--- a/src/main/kotlin/platform/sponge/creator/SpongeProjectConfig.kt
+++ b/src/main/kotlin/platform/sponge/creator/SpongeProjectConfig.kt
@@ -53,7 +53,7 @@ class SpongeProjectConfig : ProjectConfig(), MavenCreator, GradleCreator {
         return if (apiVersion < SpongeConstants.API8) {
             SpongeMavenCreator(rootDirectory, module, buildSystem, this)
         } else {
-            TODO()
+            Sponge8MavenCreator(rootDirectory, module, buildSystem, this)
         }
     }
 

--- a/src/main/kotlin/platform/sponge/creator/SpongeProjectConfig.kt
+++ b/src/main/kotlin/platform/sponge/creator/SpongeProjectConfig.kt
@@ -18,6 +18,8 @@ import com.demonwav.mcdev.creator.buildsystem.gradle.GradleCreator
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenBuildSystem
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenCreator
 import com.demonwav.mcdev.platform.PlatformType
+import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
+import com.demonwav.mcdev.util.SemanticVersion
 import com.intellij.openapi.module.Module
 import java.nio.file.Path
 
@@ -47,7 +49,12 @@ class SpongeProjectConfig : ProjectConfig(), MavenCreator, GradleCreator {
         module: Module,
         buildSystem: MavenBuildSystem
     ): ProjectCreator {
-        return SpongeMavenCreator(rootDirectory, module, buildSystem, this)
+        val apiVersion = SemanticVersion.parse(spongeApiVersion)
+        return if (apiVersion < SpongeConstants.API8) {
+            SpongeMavenCreator(rootDirectory, module, buildSystem, this)
+        } else {
+            TODO()
+        }
     }
 
     override fun buildGradleCreator(
@@ -55,6 +62,18 @@ class SpongeProjectConfig : ProjectConfig(), MavenCreator, GradleCreator {
         module: Module,
         buildSystem: GradleBuildSystem
     ): ProjectCreator {
-        return SpongeGradleCreator(rootDirectory, module, buildSystem, this)
+        val apiVersion = SemanticVersion.parse(spongeApiVersion)
+        return if (apiVersion < SpongeConstants.API8) {
+            SpongeGradleCreator(rootDirectory, module, buildSystem, this)
+        } else {
+            Sponge8GradleCreator(rootDirectory, module, buildSystem, this)
+        }
+    }
+
+    override fun configureRootGradle(rootDirectory: Path, buildSystem: GradleBuildSystem) {
+        val apiVersion = SemanticVersion.parse(spongeApiVersion)
+        if (apiVersion >= SpongeConstants.API8) {
+            buildSystem.gradleVersion = SemanticVersion.release(7, 0, 2)
+        }
     }
 }

--- a/src/main/kotlin/platform/sponge/creator/SpongeProjectCreator.kt
+++ b/src/main/kotlin/platform/sponge/creator/SpongeProjectCreator.kt
@@ -52,7 +52,7 @@ sealed class SpongeProjectCreator<T : BuildSystem>(
 
     protected fun setupDependencyStep(): SpongeDependenciesSetup {
         val spongeApiVersion = config.spongeApiVersion
-        return SpongeDependenciesSetup(buildSystem, spongeApiVersion)
+        return SpongeDependenciesSetup(buildSystem, spongeApiVersion, true)
     }
 
     protected fun setupMainClassSteps(): Pair<CreatorStep, CreatorStep> {
@@ -228,7 +228,8 @@ class SpongeMainClassModifyStep(
 
 class SpongeDependenciesSetup(
     private val buildSystem: BuildSystem,
-    private val spongeApiVersion: String
+    private val spongeApiVersion: String,
+    private val addAnnotationProcessor: Boolean
 ) : CreatorStep {
     override fun runStep(indicator: ProgressIndicator) {
         buildSystem.repositories.add(
@@ -247,13 +248,15 @@ class SpongeDependenciesSetup(
                 gradleConfiguration = "compileOnly"
             )
         )
-        buildSystem.dependencies.add(
-            BuildDependency(
-                "org.spongepowered",
-                "spongeapi",
-                spongeApiVersion,
-                gradleConfiguration = "annotationProcessor"
+        if (addAnnotationProcessor) {
+            buildSystem.dependencies.add(
+                BuildDependency(
+                    "org.spongepowered",
+                    "spongeapi",
+                    spongeApiVersion,
+                    gradleConfiguration = "annotationProcessor"
+                )
             )
-        )
+        }
     }
 }

--- a/src/main/kotlin/platform/sponge/creator/SpongeProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/sponge/creator/SpongeProjectSettingsWizard.kt
@@ -19,6 +19,7 @@ import com.demonwav.mcdev.creator.ValidatedFieldType.LIST
 import com.demonwav.mcdev.creator.ValidatedFieldType.NON_BLANK
 import com.demonwav.mcdev.platform.sponge.SpongeVersion
 import com.demonwav.mcdev.util.firstOfType
+import com.intellij.util.text.nullize
 import com.intellij.util.ui.UIUtil
 import javax.swing.JComboBox
 import javax.swing.JComponent
@@ -94,8 +95,8 @@ class SpongeProjectSettingsWizard(private val creator: MinecraftProjectCreator) 
 
         conf.pluginName = this.pluginNameField.text
         conf.mainClass = this.mainClassField.text
-        conf.description = this.descriptionField.text
-        conf.website = this.websiteField.text
+        conf.description = this.descriptionField.text?.nullize(true)
+        conf.website = this.websiteField.text?.nullize(true)
         conf.spongeApiVersion = this.spongeApiVersionBox.selectedItem as String
 
         conf.setAuthors(this.authorsField.text)

--- a/src/main/kotlin/platform/sponge/util/SpongeConstants.kt
+++ b/src/main/kotlin/platform/sponge/util/SpongeConstants.kt
@@ -10,6 +10,7 @@
 
 package com.demonwav.mcdev.platform.sponge.util
 
+import com.demonwav.mcdev.util.SemanticVersion
 import java.util.regex.Pattern
 
 object SpongeConstants {
@@ -31,4 +32,6 @@ object SpongeConstants {
     // Taken from https://github.com/SpongePowered/plugin-meta/blob/185f5c2/src/main/java/org/spongepowered/plugin/meta/PluginMetadata.java#L60
     val ID_PATTERN_STRING = "^[a-z][a-z0-9-_]{1,63}$"
     val ID_PATTERN = Pattern.compile(ID_PATTERN_STRING)
+    
+    val API8 = SemanticVersion.release(8)
 }

--- a/src/main/kotlin/platform/sponge/util/SpongeConstants.kt
+++ b/src/main/kotlin/platform/sponge/util/SpongeConstants.kt
@@ -32,6 +32,6 @@ object SpongeConstants {
     // Taken from https://github.com/SpongePowered/plugin-meta/blob/185f5c2/src/main/java/org/spongepowered/plugin/meta/PluginMetadata.java#L60
     val ID_PATTERN_STRING = "^[a-z][a-z0-9-_]{1,63}$"
     val ID_PATTERN = Pattern.compile(ID_PATTERN_STRING)
-    
+
     val API8 = SemanticVersion.release(8)
 }

--- a/src/main/kotlin/util/MinecraftTemplates.kt
+++ b/src/main/kotlin/util/MinecraftTemplates.kt
@@ -66,6 +66,13 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE_SETTINGS_GRADLE_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE_POM_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE_SUBMODULE_POM_TEMPLATE))
+            spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_MAIN_CLASS_TEMPLATE))
+            spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_BUILD_GRADLE_TEMPLATE))
+            // spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE))
+            spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_GRADLE_PROPERTIES_TEMPLATE))
+            spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SETTINGS_GRADLE_TEMPLATE))
+            // spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_POM_TEMPLATE))
+            // spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SUBMODULE_POM_TEMPLATE))
         }
 
         FileTemplateGroupDescriptor("Forge", PlatformAssets.FORGE_ICON).let { forgeGroup ->
@@ -194,6 +201,14 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
         const val SPONGE_SETTINGS_GRADLE_TEMPLATE = "Sponge settings.gradle"
         const val SPONGE_POM_TEMPLATE = "Sponge pom.xml"
         const val SPONGE_SUBMODULE_POM_TEMPLATE = "Sponge Submodule pom.xml"
+
+        const val SPONGE8_MAIN_CLASS_TEMPLATE = "Sponge 8+ Main Class.java"
+        const val SPONGE8_BUILD_GRADLE_TEMPLATE = "Sponge 8+ build.gradle.kts"
+        // const val SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE = "Sponge 8+ Submodule build.gradle.kts"
+        const val SPONGE8_GRADLE_PROPERTIES_TEMPLATE = "Sponge 8+ gradle.properties"
+        const val SPONGE8_SETTINGS_GRADLE_TEMPLATE = "Sponge 8+ settings.gradle.kts"
+        // const val SPONGE8_POM_TEMPLATE = "Sponge 8+ pom.xml"
+        // const val SPONGE8_SUBMODULE_POM_TEMPLATE = "Sponge 8+ Submodule pom.xml"
 
         const val FORGE_MAIN_CLASS_TEMPLATE = "Forge Main Class.java"
         const val FORGE_BUILD_GRADLE_TEMPLATE = "Forge build.gradle"

--- a/src/main/kotlin/util/MinecraftTemplates.kt
+++ b/src/main/kotlin/util/MinecraftTemplates.kt
@@ -204,7 +204,7 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
 
         const val SPONGE8_MAIN_CLASS_TEMPLATE = "Sponge 8+ Main Class.java"
         const val SPONGE8_BUILD_GRADLE_TEMPLATE = "Sponge 8+ build.gradle.kts"
-        // const val SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE = "Sponge 8+ Submodule build.gradle.kts"
+        const val SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE = "Sponge 8+ Submodule build.gradle.kts"
         const val SPONGE8_GRADLE_PROPERTIES_TEMPLATE = "Sponge 8+ gradle.properties"
         const val SPONGE8_SETTINGS_GRADLE_TEMPLATE = "Sponge 8+ settings.gradle.kts"
         // const val SPONGE8_POM_TEMPLATE = "Sponge 8+ pom.xml"

--- a/src/main/kotlin/util/MinecraftTemplates.kt
+++ b/src/main/kotlin/util/MinecraftTemplates.kt
@@ -68,11 +68,9 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE_SUBMODULE_POM_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_MAIN_CLASS_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_BUILD_GRADLE_TEMPLATE))
-            // spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE))
+            spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_GRADLE_PROPERTIES_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SETTINGS_GRADLE_TEMPLATE))
-            // spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_POM_TEMPLATE))
-            // spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SUBMODULE_POM_TEMPLATE))
         }
 
         FileTemplateGroupDescriptor("Forge", PlatformAssets.FORGE_ICON).let { forgeGroup ->

--- a/src/main/kotlin/util/MinecraftTemplates.kt
+++ b/src/main/kotlin/util/MinecraftTemplates.kt
@@ -67,6 +67,7 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE_POM_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE_SUBMODULE_POM_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_MAIN_CLASS_TEMPLATE))
+            spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_PLUGINS_JSON_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_BUILD_GRADLE_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE))
             spongeGroup.addTemplate(FileTemplateDescriptor(SPONGE8_GRADLE_PROPERTIES_TEMPLATE))
@@ -201,6 +202,7 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
         const val SPONGE_SUBMODULE_POM_TEMPLATE = "Sponge Submodule pom.xml"
 
         const val SPONGE8_MAIN_CLASS_TEMPLATE = "Sponge 8+ Main Class.java"
+        const val SPONGE8_PLUGINS_JSON_TEMPLATE = "Sponge 8+ plugins.json"
         const val SPONGE8_BUILD_GRADLE_TEMPLATE = "Sponge 8+ build.gradle.kts"
         const val SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE = "Sponge 8+ Submodule build.gradle.kts"
         const val SPONGE8_GRADLE_PROPERTIES_TEMPLATE = "Sponge 8+ gradle.properties"

--- a/src/main/kotlin/util/MinecraftTemplates.kt
+++ b/src/main/kotlin/util/MinecraftTemplates.kt
@@ -207,8 +207,6 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
         const val SPONGE8_SUBMODULE_BUILD_GRADLE_TEMPLATE = "Sponge 8+ Submodule build.gradle.kts"
         const val SPONGE8_GRADLE_PROPERTIES_TEMPLATE = "Sponge 8+ gradle.properties"
         const val SPONGE8_SETTINGS_GRADLE_TEMPLATE = "Sponge 8+ settings.gradle.kts"
-        // const val SPONGE8_POM_TEMPLATE = "Sponge 8+ pom.xml"
-        // const val SPONGE8_SUBMODULE_POM_TEMPLATE = "Sponge 8+ Submodule pom.xml"
 
         const val FORGE_MAIN_CLASS_TEMPLATE = "Forge Main Class.java"
         const val FORGE_BUILD_GRADLE_TEMPLATE = "Forge build.gradle"

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Main Class.java.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Main Class.java.ft
@@ -1,0 +1,79 @@
+package ${PACKAGE};
+
+import com.google.inject.Inject;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.LinearComponents;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.Server;
+import org.spongepowered.api.command.Command;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.parameter.Parameter;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.lifecycle.ConstructPluginEvent;
+import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
+import org.spongepowered.api.event.lifecycle.StartingEngineEvent;
+import org.spongepowered.api.event.lifecycle.StoppingEngineEvent;
+import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.jvm.Plugin;
+
+/**
+ * The main class of your Sponge plugin.
+ *
+ * <p>All methods are optional -- some common event registrations are included as a jumping-off point.</p>
+ */
+@Plugin("${PLUGIN_ID}")
+public class ${CLASS_NAME} {
+
+    private final PluginContainer container;
+    private final Logger logger;
+
+    @Inject
+    ${CLASS_NAME}(final PluginContainer container, final Logger logger) {
+        this.container = container;
+        this.logger = logger;
+    }
+
+    @Listener
+    public void onConstructPlugin(final ConstructPluginEvent event) {
+        // Perform any one-time setup
+        this.logger.info("Constructing ${PLUGIN_ID}");
+    }
+
+    @Listener
+    public void onServerStarting(final StartingEngineEvent<Server> event) {
+        // Any setup per-game instance. This can run multiple times when
+        // using the integrated (singleplayer) server.
+    }
+
+    @Listener
+    public void onServerStopping(final StoppingEngineEvent<Server> event) {
+        // Any tear down per-game instance. This can run multiple times when
+        // using the integrated (singleplayer) server.
+    }
+
+    @Listener
+    public void onRegisterCommands(final RegisterCommandEvent<Command.Parameterized> event) {
+        // Register a simple command
+        // When possible, all commands should be registered within a command register event
+        final Parameter.Value<String> nameParam = Parameter.string().key("name").build();
+        event.register(this.container, Command.builder()
+            .addParameter(nameParam)
+            .permission("${PLUGIN_ID}.command.greet")
+            .executor(ctx -> {
+                final String name = ctx.requireOne(nameParam);
+                ctx.sendMessage(Identity.nil(), LinearComponents.linear(
+                    NamedTextColor.AQUA,
+                    Component.text("Hello "),
+                    Component.text(name, Style.style(TextDecoration.BOLD)),
+                    Component.text("!")
+                ));
+
+                return CommandResult.success();
+            })
+            .build(), "greet", "wave");
+    }
+}

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Main Class.java.html
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Main Class.java.html
@@ -1,0 +1,15 @@
+<!--
+    Minecraft Dev for IntelliJ
+
+    https://minecraftdev.org
+
+    Copyright (c) 2021 minecraft-dev
+
+    MIT License
+-->
+
+<html>
+<body>
+<p>This is a built-in file template used to create a new main class for SpongeAPI 8.</p>
+</body>
+</html>

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Submodule build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Submodule build.gradle.kts.ft
@@ -4,7 +4,7 @@ import org.spongepowered.plugin.metadata.PluginDependency
 plugins {
     `java-library`
     id("com.github.johnrengelman.shadow")
-    id("org.spongepowered.gradle.plugin") version "1.1.0"
+    id("org.spongepowered.gradle.plugin") version "1.1.1"
 }
 
 repositories {

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Submodule build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Submodule build.gradle.kts.ft
@@ -3,14 +3,16 @@ import org.spongepowered.plugin.metadata.PluginDependency
 
 plugins {
     `java-library`
+    id("com.github.johnrengelman.shadow")
     id("org.spongepowered.gradle.plugin") version "1.1.0"
 }
 
-group = "${GROUP_ID}"
-version = "${PLUGIN_VERSION}"
-
 repositories {
     mavenCentral()
+}
+
+dependencies {
+    implementation(project(":${COMMON_PROJECT_NAME}"))
 }
 
 sponge {
@@ -70,4 +72,16 @@ tasks.withType(JavaCompile::class).configureEach {
 tasks.withType(AbstractArchiveTask::class).configureEach {
     isReproducibleFileOrder = true
     isPreserveFileTimestamps = false
+}
+
+tasks {
+    shadowJar {
+        dependencies {
+            include(dependency(":${COMMON_PROJECT_NAME}"))
+        }
+    }
+
+    build {
+        dependsOn(shadowJar)
+    }
 }

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Submodule build.gradle.kts.html
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ Submodule build.gradle.kts.html
@@ -1,0 +1,15 @@
+<!--
+    Minecraft Dev for IntelliJ
+
+    https://minecraftdev.org
+
+    Copyright (c) 2021 minecraft-dev
+
+    MIT License
+-->
+
+<html>
+<body>
+<p>This is a built-in file template used to create a new build.gradle for the multi-module projects' SpongeAPI 8 submodule.</p>
+</body>
+</html>

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ build.gradle.kts.ft
@@ -1,0 +1,73 @@
+import org.spongepowered.gradle.plugin.config.PluginLoaders
+import org.spongepowered.plugin.metadata.PluginDependency
+
+plugins {
+    `java-library`
+    id("org.spongepowered.gradle.plugin") version "1.1.0"
+}
+
+group = "${GROUP_ID}"
+version = "${PLUGIN_VERSION}"
+
+repositories {
+    mavenCentral()
+}
+
+sponge {
+    apiVersion("${SPONGEAPI_VERSION}")
+    plugin("${PLUGIN_ID}") {
+        loader(PluginLoaders.JAVA_PLAIN)
+        displayName("${PLUGIN_NAME}")
+        mainClass("${MAIN_CLASS}")
+        #if (${DESCRIPTION})
+        description("${DESCRIPTION}")
+        #else
+        // description("My plugin description")
+        #end
+        links {
+            #if (${WEBSITE})
+            homepage("${WEBSITE}")
+            #else
+            // homepage("https://spongepowered.org")
+            #end
+            // source("https://spongepowered.org/source")
+            // issues("https://spongepowered.org/issues")
+        }
+        #foreach (${AUTHOR} in ${AUTHORS})
+        contributor("${AUTHOR}") {
+            description("Author")
+        }
+        #end
+        dependency("spongeapi") {
+            loadOrder(PluginDependency.LoadOrder.AFTER)
+            optional(false)
+        }
+        #foreach (${DEPENDENCY} in ${DEPENDENCIES})
+        dependency("${DEPEDENCY}") {
+            loadOrder(PluginDependency.LoadOrder.AFTER)
+            optional(false)
+        }
+        #end
+    }
+}
+
+val javaTarget = 8 // Sponge targets a minimum of Java 8
+java {
+    sourceCompatibility = JavaVersion.toVersion(javaTarget)
+    targetCompatibility = JavaVersion.toVersion(javaTarget)
+}
+
+tasks.withType(JavaCompile::class).configureEach {
+    options.apply {
+        encoding = "utf-8" // Consistent source file encoding
+        if (JavaVersion.current().isJava10Compatible) {
+            release.set(javaTarget)
+        }
+    }
+}
+
+// Make sure all tasks which produce archives (jar, sources jar, javadoc jar, etc) produce more consistent output
+tasks.withType(AbstractArchiveTask::class).configureEach {
+    isReproducibleFileOrder = true
+    isPreserveFileTimestamps = false
+}

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ build.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ build.gradle.kts.ft
@@ -3,7 +3,7 @@ import org.spongepowered.plugin.metadata.PluginDependency
 
 plugins {
     `java-library`
-    id("org.spongepowered.gradle.plugin") version "1.1.0"
+    id("org.spongepowered.gradle.plugin") version "1.1.1"
 }
 
 group = "${GROUP_ID}"

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ build.gradle.kts.html
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ build.gradle.kts.html
@@ -1,0 +1,15 @@
+<!--
+    Minecraft Dev for IntelliJ
+
+    https://minecraftdev.org
+
+    Copyright (c) 2021 minecraft-dev
+
+    MIT License
+-->
+
+<html>
+<body>
+<p>This is a built-in file template used to create a new build.gradle for SpongeAPI 8 projects.</p>
+</body>
+</html>

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ gradle.properties.html
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ gradle.properties.html
@@ -1,0 +1,15 @@
+<!--
+    Minecraft Dev for IntelliJ
+
+    https://minecraftdev.org
+
+    Copyright (c) 2021 minecraft-dev
+
+    MIT License
+-->
+
+<html>
+<body>
+<p>This is a built-in file template used to create a new gradle.properties file for SpongeAPI 8 projects.</p>
+</body>
+</html>

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ plugins.json.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ plugins.json.ft
@@ -1,0 +1,44 @@
+{
+  "plugins": [
+    {
+      "loader": "java_plain",
+      "id": "${PLUGIN_ID}",
+      "name": "${PLUGIN_NAME}",
+      "version": "${VERSION_PLACEHOLDER}",
+      "main-class": "${MAIN_CLASS}",
+      #if (${DESCRIPTION})
+      "description": "${DESCRIPTION}",
+      #else
+      "description": "My plugin description",
+      #end
+      "links": {
+        #if (${WEBSITE})
+        "homepage": "https://spongepowered.org"
+        #end
+      },
+      "contributors": [
+        #foreach (${AUTHOR} in ${AUTHORS})
+        {
+          "name": "${AUTHOR}",
+          "description": "Author"
+        }
+        #end
+      ],
+      "dependencies": [
+        {
+          "id": "spongeapi",
+          "version": "${SPONGEAPI_VERSION}",
+          "load-order": "AFTER",
+          "optional": false
+        #foreach (${DEPENDENCY} in ${DEPENDENCIES})
+        },
+        {
+          "id": "${DEPENDENCY}",
+          "load-order": "AFTER",
+          "optional": false
+        #end
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ plugins.json.html
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ plugins.json.html
@@ -1,0 +1,15 @@
+<!--
+    Minecraft Dev for IntelliJ
+
+    https://minecraftdev.org
+
+    Copyright (c) 2021 minecraft-dev
+
+    MIT License
+-->
+
+<html>
+<body>
+<p>This is a built-in file template used to create a new plugins.json for SpongeAPI 8 Maven projects.</p>
+</body>
+</html>

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ settings.gradle.kts.ft
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ settings.gradle.kts.ft
@@ -1,0 +1,1 @@
+rootProject.name = "${PROJECT_NAME}"

--- a/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ settings.gradle.kts.html
+++ b/src/main/resources/fileTemplates/j2ee/sponge/Sponge 8+ settings.gradle.kts.html
@@ -1,0 +1,15 @@
+<!--
+    Minecraft Dev for IntelliJ
+
+    https://minecraftdev.org
+
+    Copyright (c) 2021 minecraft-dev
+
+    MIT License
+-->
+
+<html>
+<body>
+<p>This is a built-in file template used to create a new settings.gradle for SpongeAPI 8 projects.</p>
+</body>
+</html>


### PR DESCRIPTION
This adds SpongeAPI 8 plugin templates to the project creator.

The templates are based on https://github.com/SpongePowered/sponge-plugin-template
They are using the Gradle Kotlin DSL and Gradle 7, so I had to adapt some Gradle steps to take the Kotlin DSL into account.
Gradle 7 also breaks some old templates (those using the `maven` plugin or `compile` configurations for example.) This is an issue with multi-project setups and will be fixed separately.

The maven templates do not generate a plugin manifest (the Sponge 7 one didn't either so I don't consider this an important issue.)

Fixes #918 