### PR TITLE
update gradle version of default wrapper version, 5.6.1 => 7.0.2

### DIFF
--- a/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
+++ b/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
@@ -86,7 +86,7 @@ class GradleBuildSystem(
     }
 
     companion object {
-        val DEFAULT_WRAPPER_VERSION = SemanticVersion.release(5, 6, 1)
+        val DEFAULT_WRAPPER_VERSION = SemanticVersion.release(7, 0, 2)
     }
 }
 


### PR DESCRIPTION
I checked to be able to create new project with java16. (by running `gradlew runIde` command)