### PR TITLE
ForgeGradle 5 support

### DIFF
--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelFG3BuilderImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelFG3BuilderImpl.groovy
@@ -11,6 +11,8 @@
 package com.demonwav.mcdev.platform.mcp.gradle.tooling
 
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.plugins.gradle.tooling.ErrorMessageBuilder
 import org.jetbrains.plugins.gradle.tooling.ModelBuilderService
@@ -46,8 +48,20 @@ final class McpModelFG3BuilderImpl implements ModelBuilderService {
         }
 
         def taskOutput = task.outputs.files.singleFile
+
+        // Cheap way to be compatible with FG5
+        def mappings = extension.mappings
+        if (mappings instanceof Provider) {
+            mappings = mappings.get()
+        }
+
+        def accessTransformers = extension.accessTransformers
+        if (accessTransformers instanceof FileCollection) {
+            accessTransformers = accessTransformers.asList()
+        }
+
         //noinspection GroovyAssignabilityCheck
-        return new McpModelFG3Impl(minecraftDepVersions, extension.mappings, taskOutput, task.name, extension.accessTransformers)
+        return new McpModelFG3Impl(minecraftDepVersions, mappings, taskOutput, task.name, accessTransformers)
     }
 
     @Override


### PR DESCRIPTION
A ForgeGradle 5 broke the Gradle tooling extension some time ago, not too big though: 2 return types changed.

I chose the simple path and added simple instanceof checks to the FG3 model builder and assume there will be no more breaking changes for FG5.

This PR might sit until FG5 is stabilized, we'll see how it goes.