### PR TITLE
Advertise VanillaGradle way to get MC sources

### DIFF
--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/vanillagradle/VanillaGradleModelBuilderImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/vanillagradle/VanillaGradleModelBuilderImpl.groovy
@@ -1,0 +1,36 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mcp.gradle.tooling.vanillagradle
+
+import org.gradle.api.Project
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.plugins.gradle.tooling.ErrorMessageBuilder
+import org.jetbrains.plugins.gradle.tooling.ModelBuilderService
+
+class VanillaGradleModelBuilderImpl implements ModelBuilderService {
+
+    @Override
+    boolean canBuild(String modelName) {
+        return VanillaGradleModel.name == modelName
+    }
+
+    @Override
+    Object buildAll(String modelName, Project project) {
+        return new VanillaGradleModelImpl(project.plugins.hasPlugin('org.spongepowered.gradle.vanilla'))
+    }
+
+    @Override
+    ErrorMessageBuilder getErrorMessageBuilder(@NotNull Project project, @NotNull Exception e) {
+        return ErrorMessageBuilder.create(
+                project, e, "MinecraftDev import errors"
+        ).withDescription("Unable to build MinecraftDev VanillaGradle project configuration")
+    }
+}

--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/vanillagradle/VanillaGradleModelImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/vanillagradle/VanillaGradleModelImpl.groovy
@@ -1,0 +1,25 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mcp.gradle.tooling.vanillagradle
+
+class VanillaGradleModelImpl implements VanillaGradleModel, Serializable {
+
+    private final boolean hasVanillaGradle
+
+    VanillaGradleModelImpl(boolean hasVanillaGradle) {
+        this.hasVanillaGradle = hasVanillaGradle
+    }
+
+    @Override
+    boolean hasVanillaGradle() {
+        return hasVanillaGradle
+    }
+}

--- a/src/gradle-tooling-extension/java/com/demonwav/mcdev/platform/mcp/gradle/tooling/vanillagradle/VanillaGradleModel.java
+++ b/src/gradle-tooling-extension/java/com/demonwav/mcdev/platform/mcp/gradle/tooling/vanillagradle/VanillaGradleModel.java
@@ -1,0 +1,16 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mcp.gradle.tooling.vanillagradle;
+
+public interface VanillaGradleModel {
+
+    boolean hasVanillaGradle();
+}

--- a/src/gradle-tooling-extension/resources/META-INF/services/org.jetbrains.plugins.gradle.tooling.ModelBuilderService
+++ b/src/gradle-tooling-extension/resources/META-INF/services/org.jetbrains.plugins.gradle.tooling.ModelBuilderService
@@ -1,2 +1,3 @@
+com.demonwav.mcdev.platform.mcp.gradle.tooling.vanillagradle.VanillaGradleModelBuilderImpl
 com.demonwav.mcdev.platform.mcp.gradle.tooling.McpModelFG2BuilderImpl
 com.demonwav.mcdev.platform.mcp.gradle.tooling.McpModelFG3BuilderImpl

--- a/src/main/kotlin/platform/mcp/vanillagradle/VanillaGradleData.kt
+++ b/src/main/kotlin/platform/mcp/vanillagradle/VanillaGradleData.kt
@@ -1,0 +1,25 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mcp.vanillagradle
+
+import com.intellij.openapi.externalSystem.model.Key
+import com.intellij.openapi.externalSystem.model.ProjectKeys
+import com.intellij.openapi.externalSystem.model.project.AbstractExternalEntityData
+import com.intellij.openapi.externalSystem.model.project.ModuleData
+
+data class VanillaGradleData(
+    val module: ModuleData,
+    val decompileTaskName: String
+) : AbstractExternalEntityData(module.owner) {
+    companion object {
+        val KEY = Key.create(VanillaGradleData::class.java, ProjectKeys.TASK.processingWeight + 1)
+    }
+}

--- a/src/main/kotlin/platform/mcp/vanillagradle/VanillaGradleDecompileSourceProvider.kt
+++ b/src/main/kotlin/platform/mcp/vanillagradle/VanillaGradleDecompileSourceProvider.kt
@@ -1,0 +1,86 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mcp.vanillagradle
+
+import com.demonwav.mcdev.util.findModule
+import com.demonwav.mcdev.util.runGradleTaskWithCallback
+import com.intellij.codeInsight.AttachSourcesProvider
+import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.project.ProjectData
+import com.intellij.openapi.externalSystem.service.project.ExternalProjectRefreshCallback
+import com.intellij.openapi.externalSystem.task.TaskCallback
+import com.intellij.openapi.externalSystem.util.ExternalSystemUtil
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.util.ActionCallback
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiJavaFile
+import java.nio.file.Paths
+import org.jetbrains.plugins.gradle.util.GradleConstants
+import org.jetbrains.plugins.gradle.util.GradleUtil
+
+class VanillaGradleDecompileSourceProvider : AttachSourcesProvider {
+    override fun getActions(
+        orderEntries: List<LibraryOrderEntry>,
+        psiFile: PsiFile
+    ): Collection<AttachSourcesProvider.AttachSourcesAction> {
+        if (psiFile !is PsiJavaFile || !psiFile.packageName.startsWith("net.minecraft")) {
+            return emptyList()
+        }
+
+        val module = psiFile.findModule() ?: return emptyList()
+        val vgData = GradleUtil.findGradleModuleData(module)?.children
+            ?.find { it.key == VanillaGradleData.KEY }?.data as? VanillaGradleData
+            ?: return emptyList()
+        return listOf(DecompileAction(vgData.decompileTaskName))
+    }
+
+    private class DecompileAction(val decompileTaskName: String) : AttachSourcesProvider.AttachSourcesAction {
+
+        override fun getName(): String = "Decompile Minecraft"
+
+        override fun getBusyText(): String = "Decompiling Minecraft..."
+
+        override fun perform(orderEntriesContainingFile: List<LibraryOrderEntry>): ActionCallback {
+            val project = orderEntriesContainingFile.firstOrNull()?.ownerModule?.project
+                ?: return ActionCallback.REJECTED
+            val projectPath = project.basePath ?: return ActionCallback.REJECTED
+
+            val callback = ActionCallback()
+            val taskCallback = object : TaskCallback {
+                override fun onSuccess() {
+                    val importSpec = ImportSpecBuilder(project, GradleConstants.SYSTEM_ID)
+                        .callback(
+                            object : ExternalProjectRefreshCallback {
+                                override fun onSuccess(externalProject: DataNode<ProjectData>?) = callback.setDone()
+
+                                override fun onFailure(errorMessage: String, errorDetails: String?) {
+                                    callback.reject(
+                                        if (errorDetails == null) errorMessage else "$errorMessage: $errorDetails"
+                                    )
+                                }
+                            }
+                        )
+                    ExternalSystemUtil.refreshProject(projectPath, importSpec)
+                }
+
+                override fun onFailure() = callback.setRejected()
+            }
+            runGradleTaskWithCallback(
+                project,
+                Paths.get(projectPath),
+                { settings -> settings.taskNames = listOf(decompileTaskName) },
+                taskCallback
+            )
+            return callback
+        }
+    }
+}

--- a/src/main/kotlin/platform/mcp/vanillagradle/VanillaGradleProjectResolverExtension.kt
+++ b/src/main/kotlin/platform/mcp/vanillagradle/VanillaGradleProjectResolverExtension.kt
@@ -1,0 +1,37 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mcp.vanillagradle
+
+import com.demonwav.mcdev.platform.mcp.gradle.tooling.vanillagradle.VanillaGradleModel
+import com.intellij.openapi.externalSystem.model.DataNode
+import com.intellij.openapi.externalSystem.model.project.ModuleData
+import org.gradle.tooling.model.idea.IdeaModule
+import org.jetbrains.plugins.gradle.service.project.AbstractProjectResolverExtension
+
+class VanillaGradleProjectResolverExtension : AbstractProjectResolverExtension() {
+
+    override fun getExtraProjectModelClasses(): Set<Class<out Any>> =
+        setOf(VanillaGradleModel::class.java)
+
+    override fun getToolingExtensionsClasses() = extraProjectModelClasses
+
+    override fun populateModuleExtraModels(gradleModule: IdeaModule, ideModule: DataNode<ModuleData>) {
+        val vgData = resolverCtx.getExtraProject(gradleModule, VanillaGradleModel::class.java)
+        if (vgData != null) {
+            val gradleProjectPath = gradleModule.gradleProject.projectIdentifier.projectPath
+            val suffix = if (gradleProjectPath.endsWith(':')) "" else ":"
+            val decompileTaskName = gradleProjectPath + suffix + "decompile"
+            ideModule.createChild(VanillaGradleData.KEY, VanillaGradleData(ideModule.data, decompileTaskName))
+        }
+
+        super.populateModuleExtraModels(gradleModule, ideModule)
+    }
+}

--- a/src/main/kotlin/util/gradle-util.kt
+++ b/src/main/kotlin/util/gradle-util.kt
@@ -32,7 +32,7 @@ fun runGradleTaskAndWait(project: Project, dir: Path, func: (ExternalSystemTaskE
     latch.await()
 }
 
-private fun runGradleTaskWithCallback(
+fun runGradleTaskWithCallback(
     project: Project,
     dir: Path,
     func: (ExternalSystemTaskExecutionSettings) -> Unit,
@@ -40,7 +40,8 @@ private fun runGradleTaskWithCallback(
 ) {
     val settings = ExternalSystemTaskExecutionSettings().apply {
         externalSystemIdString = GradleConstants.SYSTEM_ID.id
-        externalProjectPath = dir.toString()
+        // Use forward slashes otherwise we don't get the 'short' project name but a full path on Windows
+        externalProjectPath = dir.toString().replace('\\', '/')
         func(this)
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -228,6 +228,8 @@
 
         <runConfigurationExtension implementation="com.demonwav.mcdev.platform.mcp.debug.McpRunConfigurationExtension"/>
 
+        <attachSourcesProvider implementation="com.demonwav.mcdev.platform.mcp.vanillagradle.VanillaGradleDecompileSourceProvider" />
+
         <!-- access transformer file type -->
         <fileType name="Access Transformers" language="Access Transformers" implementationClass="com.demonwav.mcdev.platform.mcp.at.AtFileType" fieldName="INSTANCE" patterns="*_at.cfg" />
         <lang.parserDefinition language="Access Transformers" implementationClass="com.demonwav.mcdev.platform.mcp.at.AtParserDefinition"/>
@@ -789,6 +791,7 @@
 
     <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">
         <projectResolve implementation="com.demonwav.mcdev.platform.mcp.gradle.McpProjectResolverExtension"/>
+        <projectResolve implementation="com.demonwav.mcdev.platform.mcp.vanillagradle.VanillaGradleProjectResolverExtension"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
VanillaGradle requires the user to run the `decompile` task to get Minecraft sources.

This PR adds an option that runs this task and refreshes the Gradle project when navigating MC decompiled sources. IntelliJ automagically opens the opens the source file in the editor once the refresh completes.

Here's what it looks like currently: 
![image](https://user-images.githubusercontent.com/13600250/124309945-cb13fb00-db6b-11eb-8903-bd96eae7a1a9.png)

The code is working correctly on single-project and basic multi-project setups (it worked fine on Sponge branch api-8 for example.)

However, this PR does not provide "MCP" data MCDev uses in some places (MC version, mappings, etc...), this is out of the scope of this PR. This is more like a proof-of-concept for this particular feature, rather than complete VanillaGradle support.

