### PR TITLE
Add license field to Forge project creator

### DIFF
--- a/src/main/kotlin/creator/LicenseStep.kt
+++ b/src/main/kotlin/creator/LicenseStep.kt
@@ -1,0 +1,41 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.creator
+
+import com.demonwav.mcdev.platform.fabric.creator.FabricTemplate
+import com.demonwav.mcdev.util.License
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+class LicenseStep(
+    private val project: Project,
+    private val rootDirectory: Path,
+    private val license: License,
+    private val author: String
+) : CreatorStep {
+
+    override fun runStep(indicator: ProgressIndicator) {
+        val licenseFile = rootDirectory.resolve("LICENSE")
+
+        val fileText = FabricTemplate.applyLicenseTemplate(project, license, author)
+
+        Files.write(
+            licenseFile,
+            fileText.toByteArray(Charsets.UTF_8),
+            StandardOpenOption.CREATE,
+            StandardOpenOption.WRITE,
+            StandardOpenOption.TRUNCATE_EXISTING
+        )
+    }
+}

--- a/src/main/kotlin/creator/LicenseStep.kt
+++ b/src/main/kotlin/creator/LicenseStep.kt
@@ -10,7 +10,7 @@
 
 package com.demonwav.mcdev.creator
 
-import com.demonwav.mcdev.platform.fabric.creator.FabricTemplate
+import com.demonwav.mcdev.platform.CommonTemplate
 import com.demonwav.mcdev.util.License
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
@@ -28,7 +28,7 @@ class LicenseStep(
     override fun runStep(indicator: ProgressIndicator) {
         val licenseFile = rootDirectory.resolve("LICENSE")
 
-        val fileText = FabricTemplate.applyLicenseTemplate(project, license, author)
+        val fileText = CommonTemplate.applyLicenseTemplate(project, license, author)
 
         Files.write(
             licenseFile,

--- a/src/main/kotlin/platform/BaseTemplate.kt
+++ b/src/main/kotlin/platform/BaseTemplate.kt
@@ -10,8 +10,10 @@
 
 package com.demonwav.mcdev.platform
 
+import com.demonwav.mcdev.util.License
 import com.intellij.ide.fileTemplates.FileTemplateManager
 import com.intellij.openapi.project.Project
+import java.time.ZonedDateTime
 
 abstract class BaseTemplate {
 
@@ -26,5 +28,17 @@ abstract class BaseTemplate {
         properties?.let { prop -> allProperties.putAll(prop) }
 
         return template.getText(allProperties)
+    }
+
+    fun applyLicenseTemplate(
+        project: Project,
+        license: License,
+        author: String
+    ): String {
+        val props = mapOf(
+            "YEAR" to ZonedDateTime.now().year.toString(),
+            "AUTHOR" to author
+        )
+        return project.applyTemplate("${license.id}.txt", props)
     }
 }

--- a/src/main/kotlin/platform/BaseTemplate.kt
+++ b/src/main/kotlin/platform/BaseTemplate.kt
@@ -10,10 +10,8 @@
 
 package com.demonwav.mcdev.platform
 
-import com.demonwav.mcdev.util.License
 import com.intellij.ide.fileTemplates.FileTemplateManager
 import com.intellij.openapi.project.Project
-import java.time.ZonedDateTime
 
 abstract class BaseTemplate {
 
@@ -28,17 +26,5 @@ abstract class BaseTemplate {
         properties?.let { prop -> allProperties.putAll(prop) }
 
         return template.getText(allProperties)
-    }
-
-    fun applyLicenseTemplate(
-        project: Project,
-        license: License,
-        author: String
-    ): String {
-        val props = mapOf(
-            "YEAR" to ZonedDateTime.now().year.toString(),
-            "AUTHOR" to author
-        )
-        return project.applyTemplate("${license.id}.txt", props)
     }
 }

--- a/src/main/kotlin/platform/CommonTemplate.kt
+++ b/src/main/kotlin/platform/CommonTemplate.kt
@@ -1,0 +1,30 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform
+
+import com.demonwav.mcdev.util.License
+import com.intellij.openapi.project.Project
+import java.time.ZonedDateTime
+
+object CommonTemplate : BaseTemplate() {
+
+    fun applyLicenseTemplate(
+        project: Project,
+        license: License,
+        author: String
+    ): String {
+        val props = mapOf(
+            "YEAR" to ZonedDateTime.now().year.toString(),
+            "AUTHOR" to author
+        )
+        return project.applyTemplate("${license.id}.txt", props)
+    }
+}

--- a/src/main/kotlin/platform/fabric/creator/FabricProjectCreator.kt
+++ b/src/main/kotlin/platform/fabric/creator/FabricProjectCreator.kt
@@ -12,6 +12,7 @@ package com.demonwav.mcdev.platform.fabric.creator
 
 import com.demonwav.mcdev.creator.BaseProjectCreator
 import com.demonwav.mcdev.creator.CreatorStep
+import com.demonwav.mcdev.creator.LicenseStep
 import com.demonwav.mcdev.creator.PostMultiModuleAware
 import com.demonwav.mcdev.creator.buildsystem.BuildSystem
 import com.demonwav.mcdev.creator.buildsystem.gradle.BasicGradleFinalizerStep
@@ -22,7 +23,6 @@ import com.demonwav.mcdev.creator.buildsystem.gradle.GradleWrapperStep
 import com.demonwav.mcdev.creator.buildsystem.gradle.SimpleGradleSetupStep
 import com.demonwav.mcdev.platform.fabric.EntryPoint
 import com.demonwav.mcdev.platform.fabric.util.FabricConstants
-import com.demonwav.mcdev.util.License
 import com.demonwav.mcdev.util.addAnnotation
 import com.demonwav.mcdev.util.addImplements
 import com.demonwav.mcdev.util.addMethod
@@ -58,7 +58,6 @@ import com.intellij.psi.PsiModifierListOwner
 import com.intellij.util.IncorrectOperationException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption
 import java.util.Locale
 
 class FabricProjectCreator(
@@ -83,7 +82,7 @@ class FabricProjectCreator(
         }
         steps += GradleGitignoreStep(project, rootDirectory)
         config.license?.let {
-            steps += LicenseStep(project, rootDirectory, it, config)
+            steps += LicenseStep(project, rootDirectory, it, config.authors.joinToString(", "))
         }
         steps += BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem)
         if (config.mixins) {
@@ -107,7 +106,7 @@ class FabricProjectCreator(
             steps += GenSourcesStep(project, rootDirectory)
         }
         config.license?.let {
-            steps += LicenseStep(project, rootDirectory, it, config)
+            steps += LicenseStep(project, rootDirectory, it, config.authors.joinToString(", "))
         }
         if (config.mixins) {
             steps += MixinConfigStep(project, buildSystem)
@@ -142,28 +141,6 @@ class GenSourcesStep(
             settings.vmOptions = "-Xmx1G"
         }
         indicator.text2 = null
-    }
-}
-
-class LicenseStep(
-    private val project: Project,
-    private val rootDirectory: Path,
-    private val license: License,
-    private val config: FabricProjectConfig
-) : CreatorStep {
-
-    override fun runStep(indicator: ProgressIndicator) {
-        val licenseFile = rootDirectory.resolve("LICENSE")
-
-        val fileText = FabricTemplate.applyLicenseTemplate(project, license, config)
-
-        Files.write(
-            licenseFile,
-            fileText.toByteArray(Charsets.UTF_8),
-            StandardOpenOption.CREATE,
-            StandardOpenOption.WRITE,
-            StandardOpenOption.TRUNCATE_EXISTING
-        )
     }
 }
 

--- a/src/main/kotlin/platform/fabric/creator/FabricTemplate.kt
+++ b/src/main/kotlin/platform/fabric/creator/FabricTemplate.kt
@@ -23,7 +23,6 @@ import com.demonwav.mcdev.util.MinecraftTemplates.Companion.FABRIC_SUBMODULE_BUI
 import com.demonwav.mcdev.util.MinecraftTemplates.Companion.FABRIC_SUBMODULE_GRADLE_PROPERTIES_TEMPLATE
 import com.demonwav.mcdev.util.toPackageName
 import com.intellij.openapi.project.Project
-import java.time.ZonedDateTime
 
 object FabricTemplate : BaseTemplate() {
 
@@ -92,18 +91,6 @@ object FabricTemplate : BaseTemplate() {
         config: FabricProjectConfig
     ): String {
         return project.applyGradleTemplate(FABRIC_SUBMODULE_GRADLE_PROPERTIES_TEMPLATE, buildSystem, config)
-    }
-
-    fun applyLicenseTemplate(
-        project: Project,
-        license: License,
-        config: FabricProjectConfig
-    ): String {
-        val props = mapOf(
-            "YEAR" to ZonedDateTime.now().year.toString(),
-            "AUTHOR" to config.authors.joinToString(", ")
-        )
-        return project.applyTemplate("${license.id}.txt", props)
     }
 
     fun applyFabricModJsonTemplate(

--- a/src/main/kotlin/platform/forge/creator/Fg3Template.kt
+++ b/src/main/kotlin/platform/forge/creator/Fg3Template.kt
@@ -131,7 +131,8 @@ object Fg3Template : BaseTemplate() {
             "MOD_NAME" to config.pluginName,
             "FORGE_SPEC_VERSION" to config.forgeVersion.parts[0].versionString,
             "MC_VERSION" to config.mcVersion.toString(),
-            "MC_NEXT_VERSION" to "1.$nextMcVersion"
+            "MC_NEXT_VERSION" to "1.$nextMcVersion",
+            "LICENSE" to config.license.toString()
         )
         props["DESCRIPTION"] = config.description ?: ""
         config.updateUrl?.let { url ->

--- a/src/main/kotlin/platform/forge/creator/ForgeProjectConfig.kt
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectConfig.kt
@@ -18,6 +18,7 @@ import com.demonwav.mcdev.creator.buildsystem.gradle.GradleCreator
 import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.forge.ForgeModuleType
 import com.demonwav.mcdev.platform.mcp.McpVersionPair
+import com.demonwav.mcdev.util.License
 import com.demonwav.mcdev.util.SemanticVersion
 import com.intellij.openapi.module.Module
 import java.nio.file.Path
@@ -35,6 +36,7 @@ class ForgeProjectConfig : ProjectConfig(), GradleCreator {
     var forgeVersion: SemanticVersion = SemanticVersion.release()
     var mcVersion: SemanticVersion = SemanticVersion.release()
     var mixins = false
+    var license = License.ALL_RIGHTS_RESERVED
 
     override val preferredBuildSystem = BuildSystemType.GRADLE
 

--- a/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
@@ -13,6 +13,7 @@ package com.demonwav.mcdev.platform.forge.creator
 import com.demonwav.mcdev.creator.BaseProjectCreator
 import com.demonwav.mcdev.creator.BasicJavaClassStep
 import com.demonwav.mcdev.creator.CreatorStep
+import com.demonwav.mcdev.creator.LicenseStep
 import com.demonwav.mcdev.creator.buildsystem.BuildSystem
 import com.demonwav.mcdev.creator.buildsystem.gradle.BasicGradleFinalizerStep
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleBuildSystem
@@ -135,6 +136,7 @@ open class Fg3ProjectCreator(
             Fg3ProjectFilesStep(project, buildSystem, config),
             Fg3CompileJavaStep(project, rootDirectory),
             GradleGitignoreStep(project, rootDirectory),
+            LicenseStep(project, rootDirectory, config.license, config.authors.joinToString(", ")),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem),
             ForgeRunConfigsStep(buildSystem, rootDirectory, config, CreatedModuleType.SINGLE)
         )
@@ -161,6 +163,7 @@ open class Fg3ProjectCreator(
             setupMainClassStep(),
             Fg3ProjectFilesStep(project, buildSystem, config),
             Fg3CompileJavaStep(project, rootDirectory),
+            LicenseStep(project, rootDirectory, config.license, config.authors.joinToString(", ")),
             ForgeRunConfigsStep(buildSystem, projectBaseDir, config, CreatedModuleType.MULTI)
         )
 

--- a/src/main/kotlin/platform/forge/creator/ForgeProjectSettingsWizard.form
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectSettingsWizard.form
@@ -95,7 +95,7 @@
                 </constraints>
                 <properties/>
               </component>
-              <grid id="84349" layout-manager="GridLayoutManager" row-count="1" column-count="8" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="84349" layout-manager="GridLayoutManager" row-count="1" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -166,11 +166,27 @@
                   </hspacer>
                   <component id="68d62" class="javax.swing.JCheckBox" binding="mixinsCheckbox">
                     <constraints>
-                      <grid row="0" column="7" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="0" column="9" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <selected value="false"/>
                       <text value="Use Mixins"/>
+                    </properties>
+                  </component>
+                  <component id="c3f97" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="7" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="    License"/>
+                    </properties>
+                  </component>
+                  <component id="3d838" class="javax.swing.JComboBox" binding="licenseBox">
+                    <constraints>
+                      <grid row="0" column="8" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <model/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/kotlin/platform/forge/creator/ForgeProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectSettingsWizard.kt
@@ -21,9 +21,11 @@ import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.forge.version.ForgeVersion
 import com.demonwav.mcdev.platform.mcp.version.McpVersion
 import com.demonwav.mcdev.platform.mcp.version.McpVersionEntry
+import com.demonwav.mcdev.util.License
 import com.demonwav.mcdev.util.SemanticVersion
 import com.demonwav.mcdev.util.modUpdateStep
 import com.intellij.ui.CollectionComboBoxModel
+import com.intellij.ui.EnumComboBoxModel
 import java.awt.event.ActionListener
 import javax.swing.JCheckBox
 import javax.swing.JComboBox
@@ -56,6 +58,7 @@ class ForgeProjectSettingsWizard(private val creator: MinecraftProjectCreator) :
     private lateinit var authorsField: JTextField
     private lateinit var websiteField: JTextField
     private lateinit var updateUrlField: JTextField
+    private lateinit var licenseBox: JComboBox<License>
     private lateinit var mixinsCheckbox: JCheckBox
     private lateinit var minecraftVersionBox: JComboBox<SemanticVersion>
     private lateinit var forgeVersionBox: JComboBox<SemanticVersion>
@@ -132,6 +135,9 @@ class ForgeProjectSettingsWizard(private val creator: MinecraftProjectCreator) :
             return
         }
         currentJob = updateVersions()
+
+        licenseBox.model = EnumComboBoxModel(License::class.java)
+        licenseBox.selectedItem = License.ALL_RIGHTS_RESERVED
     }
 
     private fun setForgeVersion(data: Data) {
@@ -175,6 +181,7 @@ class ForgeProjectSettingsWizard(private val creator: MinecraftProjectCreator) :
         }
 
         conf.mixins = mixinsCheckbox.isSelected
+        conf.license = licenseBox.selectedItem as? License ?: License.ALL_RIGHTS_RESERVED
         conf.mcVersion = this.version ?: SemanticVersion.release()
     }
 

--- a/src/main/resources/fileTemplates/j2ee/forge/mods.toml.ft
+++ b/src/main/resources/fileTemplates/j2ee/forge/mods.toml.ft
@@ -9,7 +9,7 @@ modLoader="javafml" #mandatory
 loaderVersion="[${FORGE_SPEC_VERSION},)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
-license="All rights reserved"
+license="${LICENSE}"
 # A URL to refer people to when problems occur with this mod
 #issueTrackerURL="http://my.issue.tracker/" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader


### PR DESCRIPTION
Allows to set the license of a Forge mod from the project creator.

![image](https://user-images.githubusercontent.com/13600250/124316317-b89ebf00-db75-11eb-9cfe-09ef5f08d912.png)

The combobox is wider than necessary because some license names are quite long.

The default selected license is `All Rights Reserved`, like in the MDK.