### PR TITLE
Add @At filters

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/AccessorHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/AccessorHandler.kt
@@ -57,10 +57,10 @@ class AccessorHandler : MixinMemberAnnotationHandler {
         return listOf(FieldTargetMember(targetClass, field))
     }
 
-    override fun createUnresolvedMessage(annotation: PsiAnnotation, unresolvedTargetClasses: String): String? {
+    override fun createUnresolvedMessage(annotation: PsiAnnotation): String? {
         val method = annotation.parentOfType<PsiMethod>() ?: return null
         val accessorInfo = getAccessorInfo(annotation, method) ?: return "Invalid accessor name ${method.name}"
-        return "Cannot find field ${accessorInfo.name} in target class $unresolvedTargetClasses"
+        return "Cannot find field ${accessorInfo.name} in target class"
     }
 
     private fun getAccessorInfo(accessor: PsiAnnotation, member: PsiMember): AccessorInfo? {

--- a/src/main/kotlin/platform/mixin/handlers/InvokerHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InvokerHandler.kt
@@ -56,10 +56,10 @@ class InvokerHandler : MixinMemberAnnotationHandler {
         return listOf(MethodTargetMember(targetClass, method))
     }
 
-    override fun createUnresolvedMessage(annotation: PsiAnnotation, unresolvedTargetClasses: String): String? {
+    override fun createUnresolvedMessage(annotation: PsiAnnotation): String? {
         val method = annotation.parentOfType<PsiMethod>() ?: return null
         val targetName = getInvokerTargetName(annotation, method) ?: return "Invalid invoker name ${method.name}"
-        return "Cannot find method $targetName in target class $unresolvedTargetClasses"
+        return "Cannot find method $targetName in target class"
     }
 
     private fun getInvokerTargetName(invoker: PsiAnnotation, member: PsiMember): String? {

--- a/src/main/kotlin/platform/mixin/handlers/MixinMemberAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/MixinMemberAnnotationHandler.kt
@@ -10,6 +10,7 @@
 
 package com.demonwav.mcdev.platform.mixin.handlers
 
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.InsnResolutionInfo
 import com.demonwav.mcdev.platform.mixin.util.FieldTargetMember
 import com.demonwav.mcdev.platform.mixin.util.MethodTargetMember
 import com.demonwav.mcdev.platform.mixin.util.findSourceElement
@@ -19,8 +20,12 @@ import com.intellij.psi.PsiElement
 import org.objectweb.asm.tree.ClassNode
 
 interface MixinMemberAnnotationHandler : MixinAnnotationHandler {
-    override fun isUnresolved(annotation: PsiAnnotation, targetClass: ClassNode): Boolean {
-        return resolveTarget(annotation, targetClass).isEmpty()
+    override fun isUnresolved(annotation: PsiAnnotation, targetClass: ClassNode): InsnResolutionInfo.Failure? {
+        return if (resolveTarget(annotation, targetClass).isEmpty()) {
+            InsnResolutionInfo.Failure()
+        } else {
+            null
+        }
     }
 
     override fun resolveForNavigation(annotation: PsiAnnotation, targetClass: ClassNode): List<PsiElement> {

--- a/src/main/kotlin/platform/mixin/handlers/OverwriteHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/OverwriteHandler.kt
@@ -27,9 +27,9 @@ class OverwriteHandler : MixinMemberAnnotationHandler {
         return listOf(MethodTargetMember(targetClass, targetMethod))
     }
 
-    override fun createUnresolvedMessage(annotation: PsiAnnotation, unresolvedTargetClasses: String): String? {
+    override fun createUnresolvedMessage(annotation: PsiAnnotation): String? {
         val method = annotation.parentOfType<PsiMethod>() ?: return null
-        return "Unresolved method ${method.name} in target class $unresolvedTargetClasses"
+        return "Unresolved method ${method.name} in target class"
     }
 
     companion object {

--- a/src/main/kotlin/platform/mixin/handlers/ShadowHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/ShadowHandler.kt
@@ -10,6 +10,7 @@
 
 package com.demonwav.mcdev.platform.mixin.handlers
 
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.InsnResolutionInfo
 import com.demonwav.mcdev.platform.mixin.util.FieldTargetMember
 import com.demonwav.mcdev.platform.mixin.util.MethodTargetMember
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants
@@ -53,18 +54,21 @@ class ShadowHandler : MixinMemberAnnotationHandler {
         }
     }
 
-    override fun isUnresolved(annotation: PsiAnnotation, targetClass: ClassNode): Boolean {
-        return !hasAliases(annotation) && super.isUnresolved(annotation, targetClass)
+    override fun isUnresolved(annotation: PsiAnnotation, targetClass: ClassNode): InsnResolutionInfo.Failure? {
+        if (hasAliases(annotation)) {
+            return null
+        }
+        return super.isUnresolved(annotation, targetClass)
     }
 
-    override fun createUnresolvedMessage(annotation: PsiAnnotation, unresolvedTargetClasses: String): String? {
+    override fun createUnresolvedMessage(annotation: PsiAnnotation): String? {
         val member = annotation.parentOfType<PsiMember>() ?: return null
         val type = when (member) {
             is PsiMethod -> "method"
             is PsiField -> "field"
             else -> return null
         }
-        return "Unresolved $type ${member.name} in target class $unresolvedTargetClasses"
+        return "Unresolved $type ${member.name} in target class"
     }
 
     fun findFirstShadowTargetForNavigation(member: PsiMember): SmartPsiElementPointer<PsiElement>? {

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/FieldInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/FieldInjectionPoint.kt
@@ -53,7 +53,7 @@ class FieldInjectionPoint : QualifiedInjectionPoint<PsiField>() {
         return target?.let { MyNavigationVisitor(targetClass, it, arrayAccess) }
     }
 
-    override fun createCollectVisitor(
+    override fun doCreateCollectVisitor(
         at: PsiAnnotation,
         target: MixinSelector?,
         targetClass: ClassNode,

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/HeadInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/HeadInjectionPoint.kt
@@ -23,7 +23,7 @@ import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodNode
 
 class HeadInjectionPoint : InjectionPoint<PsiElement>() {
-    override fun createCollectVisitor(
+    override fun doCreateCollectVisitor(
         at: PsiAnnotation,
         target: MixinSelector?,
         targetClass: ClassNode,

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/MethodInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/MethodInjectionPoint.kt
@@ -38,7 +38,7 @@ class MethodInjectionPoint : AbstractMethodInjectionPoint() {
         return target?.let { MyNavigationVisitor(targetClass, it) }
     }
 
-    override fun createCollectVisitor(
+    override fun doCreateCollectVisitor(
         at: PsiAnnotation,
         target: MixinSelector?,
         targetClass: ClassNode,

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/NewInsnInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/NewInsnInjectionPoint.kt
@@ -63,7 +63,7 @@ class NewInsnInjectionPoint : InjectionPoint<PsiMember>() {
         return getTarget(at, target)?.let { MyNavigationVisitor(it) }
     }
 
-    override fun createCollectVisitor(
+    override fun doCreateCollectVisitor(
         at: PsiAnnotation,
         target: MixinSelector?,
         targetClass: ClassNode,

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/ReturnInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/ReturnInjectionPoint.kt
@@ -41,7 +41,7 @@ abstract class AbstractReturnInjectionPoint(private val tailOnly: Boolean) : Inj
         return MyNavigationVisitor(tailOnly)
     }
 
-    override fun createCollectVisitor(
+    override fun doCreateCollectVisitor(
         at: PsiAnnotation,
         target: MixinSelector?,
         targetClass: ClassNode,
@@ -137,7 +137,13 @@ abstract class AbstractReturnInjectionPoint(private val tailOnly: Boolean) : Inj
                 return true
             }
             if (tailOnly) {
-                Iterable { insns.iterator() }.lastOrNull(::insnHandler)
+                var insn = insns.last
+                while (insn != null) {
+                    if (insnHandler(insn)) {
+                        break
+                    }
+                    insn = insn.previous
+                }
             } else {
                 insns.iterator().forEach(::insnHandler)
             }

--- a/src/main/kotlin/platform/mixin/insight/MixinTargetLineMarkerProvider.kt
+++ b/src/main/kotlin/platform/mixin/insight/MixinTargetLineMarkerProvider.kt
@@ -58,7 +58,7 @@ class MixinTargetLineMarkerProvider : LineMarkerProviderDescriptor() {
                 MixinAnnotationHandler.forMixinAnnotation(qName)?.let { it to annotation }
             }
         } ?: return null
-        if (handler.isUnresolved(annotation)) {
+        if (handler.isUnresolved(annotation) != null) {
             return null
         }
         val simpleName = annotation.qualifiedName?.substringAfterLast('.') ?: return null

--- a/src/main/kotlin/platform/mixin/inspection/MixinAnnotationTargetInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/MixinAnnotationTargetInspection.kt
@@ -11,13 +11,16 @@
 package com.demonwav.mcdev.platform.mixin.inspection
 
 import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.AtResolver
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.InsnResolutionInfo
+import com.demonwav.mcdev.platform.mixin.util.MethodTargetMember
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
+import com.demonwav.mcdev.util.ifEmpty
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.codeInspection.RemoveAnnotationQuickFix
 import com.intellij.psi.JavaElementVisitor
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.PsiField
-import com.intellij.psi.PsiMethod
 import com.intellij.psi.util.parentOfType
 
 class MixinAnnotationTargetInspection : MixinInspection() {
@@ -25,28 +28,60 @@ class MixinAnnotationTargetInspection : MixinInspection() {
 
     override fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor {
         return object : JavaElementVisitor() {
-            override fun visitField(field: PsiField) {
-                super.visitField(field)
-                processAnnotations(field.annotations)
-            }
-
-            override fun visitMethod(method: PsiMethod) {
-                super.visitMethod(method)
-                processAnnotations(method.annotations)
-            }
-
-            private fun processAnnotations(annotations: Array<PsiAnnotation>) {
-                for (annotation in annotations) {
-                    val qName = annotation.qualifiedName ?: continue
-                    val handler = MixinAnnotationHandler.forMixinAnnotation(qName) ?: continue
-                    val unresolvedClasses = handler.getUnresolvedClasses(annotation)
-                    if (unresolvedClasses.isNotEmpty()) {
-                        val unresolvedClassesStr = unresolvedClasses.joinToString(", ") { it.substringAfterLast('/') }
-                        val message = handler.createUnresolvedMessage(annotation, unresolvedClassesStr) ?: continue
-                        val quickFix = RemoveAnnotationQuickFix(annotation, annotation.parentOfType())
-                        holder.registerProblem(annotation, message, quickFix)
+            override fun visitAnnotation(annotation: PsiAnnotation) {
+                val qName = annotation.qualifiedName ?: return
+                if (qName == AT) {
+                    var parentAnnotation = annotation.parentOfType<PsiAnnotation>()
+                    while (parentAnnotation != null) {
+                        val parentQName = parentAnnotation.qualifiedName ?: return
+                        if (MixinAnnotationHandler.forMixinAnnotation(parentQName) != null) {
+                            break
+                        }
+                        parentAnnotation = parentAnnotation.parentOfType()
+                    }
+                    if (parentAnnotation == null) {
+                        return
+                    }
+                    val parentQName = parentAnnotation.qualifiedName ?: return
+                    val handler = MixinAnnotationHandler.forMixinAnnotation(parentQName) ?: return
+                    val targets = handler.resolveTarget(parentAnnotation).ifEmpty { return }
+                    val failure = targets.asSequence()
+                        .mapNotNull {
+                            (it as? MethodTargetMember)?.classAndMethod
+                        }
+                        // group by class
+                        .groupBy { it.clazz.name }
+                        .values.asSequence()
+                        // for each class there must be at least one successful match
+                        .mapNotNull classLoop@{ methods ->
+                            methods
+                                .map {
+                                    AtResolver(annotation, it.clazz, it.method).isUnresolved() ?: return@classLoop null
+                                }
+                                .reduceOrNull(InsnResolutionInfo.Failure::combine) ?: InsnResolutionInfo.Failure()
+                        }
+                        .reduceOrNull(InsnResolutionInfo.Failure::combine)
+                    if (failure != null) {
+                        addProblem(annotation, "Could not resolve @At target", failure)
+                    }
+                } else {
+                    val handler = MixinAnnotationHandler.forMixinAnnotation(qName) ?: return
+                    val failure = handler.isUnresolved(annotation)
+                    if (failure != null) {
+                        val message = handler.createUnresolvedMessage(annotation) ?: return
+                        addProblem(annotation, message, failure)
                     }
                 }
+            }
+
+            private fun addProblem(annotation: PsiAnnotation, message: String, failure: InsnResolutionInfo.Failure) {
+                val nameElement = annotation.nameReferenceElement ?: return
+                var betterMessage = message
+                if (failure.filterToBlame != null) {
+                    betterMessage += " (filtered out by ${failure.filterToBlame})"
+                }
+                val quickFix = RemoveAnnotationQuickFix(annotation, annotation.parentOfType())
+                holder.registerProblem(nameElement, message, quickFix)
             }
         }
     }

--- a/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
@@ -71,7 +71,11 @@ object TargetReference : PolyReferenceResolver(), MixinReference {
     override fun isUnresolved(context: PsiElement): Boolean {
         val at = context.parentOfType<PsiAnnotation>() ?: return true
         val targets = getTargets(at)?.ifEmpty { return true } ?: return false
-        return targets.all { AtResolver(at, it.clazz, it.method).isUnresolved() }
+        return targets.all {
+            val failure = AtResolver(at, it.clazz, it.method).isUnresolved()
+            // leave it if there is a filter to blame, the target reference was at least resolved
+            failure != null && failure.filterToBlame == null
+        }
     }
 
     fun resolveNavigationTargets(context: PsiElement): Array<PsiElement>? {

--- a/src/test/kotlin/platform/mixin/AccessorMixinTest.kt
+++ b/src/test/kotlin/platform/mixin/AccessorMixinTest.kt
@@ -262,7 +262,7 @@ class AccessorMixinTest : BaseMixinTest() {
         
         @Mixin(MixinBase.class)
         public interface AccessorMixinTargetMixin {
-            <error descr="Cannot find field foo in target class MixinBase">@Accessor</error> String getFoo();
+            @<error descr="Cannot find field foo in target class">Accessor</error> String getFoo();
         }
         """
     ) {
@@ -283,7 +283,7 @@ class AccessorMixinTest : BaseMixinTest() {
         
         @Mixin(MixinBase.class)
         public interface AccessorMixinTargetMixin {
-            <error descr="Cannot find field foo in target class MixinBase">@Accessor("foo")</error> String bar();
+            @<error descr="Cannot find field foo in target class">Accessor</error>("foo") String bar();
         }
         """
     ) {
@@ -304,7 +304,7 @@ class AccessorMixinTest : BaseMixinTest() {
         
         @Mixin(MixinBase.class)
         public interface AccessorMixinTargetMixin {
-            <error descr="Cannot find method foo in target class MixinBase">@Invoker</error> String callFoo();
+            @<error descr="Cannot find method foo in target class">Invoker</error> String callFoo();
         }
         """
     ) {
@@ -325,7 +325,7 @@ class AccessorMixinTest : BaseMixinTest() {
         
         @Mixin(MixinBase.class)
         public interface AccessorMixinTargetMixin {
-            <error descr="Cannot find method foo in target class MixinBase">@Invoker("foo")</error> String bar();
+            @<error descr="Cannot find method foo in target class">Invoker</error>("foo") String bar();
         }
         """
     ) {
@@ -346,7 +346,7 @@ class AccessorMixinTest : BaseMixinTest() {
         
         @Mixin(MixinBase.class)
         public interface AccessorMixinTargetMixin {
-            <error descr="Cannot find method <init> in target class MixinBase">@Invoker("<init>")</error> String construct(String invalidArg);
+            @<error descr="Cannot find method <init> in target class">Invoker</error>("<init>") String construct(String invalidArg);
         }
         """
     ) {

--- a/src/test/kotlin/platform/mixin/shadow/ShadowTargetInspectionTest.kt
+++ b/src/test/kotlin/platform/mixin/shadow/ShadowTargetInspectionTest.kt
@@ -52,7 +52,7 @@ class ShadowTargetInspectionTest : BaseMixinTest() {
                     @Shadow public String wrongAccessor;
                     @Shadow protected String noFinal;
 
-                    <error descr="Unresolved field nonExistent in target class MixinBase">@Shadow</error> public String nonExistent;
+                    @<error descr="Unresolved field nonExistent in target class">Shadow</error> public String nonExistent;
 
                     @Shadow protected String twoIssues;
                 }


### PR DESCRIPTION
Add filters to @At results, which handles `opcode`, `slice` and `ordinal`.

After implementing this I noticed that it caused the error messages to be a little confusing, so I also refactored a little how unresolved target errors are handled and reported.

I also added support for `ldc=...` in `INVOKE_STRING` to fix a false positive in Sponge.