### PR TITLE
Updated gradle to 7.3 to fix crashes when creating a project with java 17

### DIFF
--- a/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
+++ b/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
@@ -87,7 +87,7 @@ class GradleBuildSystem(
     }
 
     companion object {
-        val DEFAULT_WRAPPER_VERSION = SemanticVersion.release(7, 1, 1)
+        val DEFAULT_WRAPPER_VERSION = SemanticVersion.release(7, 3)
     }
 }
 

--- a/src/main/kotlin/platform/fabric/creator/FabricProjectConfig.kt
+++ b/src/main/kotlin/platform/fabric/creator/FabricProjectConfig.kt
@@ -71,6 +71,6 @@ class FabricProjectConfig : ProjectConfig(), GradleCreator {
 
     override fun configureRootGradle(rootDirectory: Path, buildSystem: GradleBuildSystem) {
         buildSystem.gradleVersion =
-            if (semanticMcVersion >= MinecraftVersions.MC1_17) SemanticVersion.release(7, 1, 1) else gradleVersion
+            if (semanticMcVersion >= MinecraftVersions.MC1_17) SemanticVersion.release(7, 3) else gradleVersion
     }
 }

--- a/src/main/kotlin/platform/fabric/creator/FabricProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/fabric/creator/FabricProjectSettingsWizard.kt
@@ -258,7 +258,7 @@ class FabricProjectSettingsWizard(private val creator: MinecraftProjectCreator) 
         }
         if (conf.loomVersion >= SemanticVersion.release(0, 7)) {
             // TemplateMakerFabric incorrectly indicates loom 0.8 requires Gradle 6...
-            conf.gradleVersion = SemanticVersion.release(7, 1, 1)
+            conf.gradleVersion = SemanticVersion.release(7, 3)
         }
         conf.environment = when ((environmentBox.selectedItem as? String)?.toLowerCase(Locale.ROOT)) {
             "client" -> Side.CLIENT

--- a/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
@@ -180,7 +180,7 @@ open class Fg3ProjectCreator(
     }
 
     companion object {
-        val FG5_WRAPPER_VERSION = SemanticVersion.release(7, 1, 1)
+        val FG5_WRAPPER_VERSION = SemanticVersion.release(7, 3)
     }
 }
 


### PR DESCRIPTION
Only changed changed gradle wrapper version from 7.1.1 to 7.2 
I tested creating a new forge 1.16.5 and fabric 1.17.1 project with Intellij 2021.2 and didn't get any errors