### PR TITLE
Cleanup and basic @ModifyVariable support

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
@@ -113,10 +113,11 @@ abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
     open fun resolveInstructions(
         annotation: PsiAnnotation,
         targetClass: ClassNode,
-        targetMethod: MethodNode
+        targetMethod: MethodNode,
+        mode: CollectVisitor.Mode = CollectVisitor.Mode.MATCH_ALL
     ): List<CollectVisitor.Result<*>> {
         val at = annotation.findAttributeValue("at") as? PsiAnnotation ?: return emptyList()
-        return AtResolver(at, targetClass, targetMethod).resolveInstructions()
+        return AtResolver(at, targetClass, targetMethod).resolveInstructions(mode)
     }
 
     /**

--- a/src/main/kotlin/platform/mixin/handlers/ModifyArgsHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/ModifyArgsHandler.kt
@@ -40,7 +40,8 @@ class ModifyArgsHandler : InjectorAnnotationHandler() {
                     ParameterGroup(listOf(Parameter("args", argsType))),
                     ParameterGroup(
                         collectTargetMethodParameters(annotation.project, targetClass, targetMethod),
-                        required = false
+                        required = ParameterGroup.RequiredLevel.OPTIONAL,
+                        isVarargs = true
                     )
                 ),
                 PsiType.VOID

--- a/src/main/kotlin/platform/mixin/handlers/ModifyVariableHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/ModifyVariableHandler.kt
@@ -10,8 +10,27 @@
 
 package com.demonwav.mcdev.platform.mixin.handlers
 
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.AbstractLoadInjectionPoint
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.CollectVisitor
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.InjectionPoint
 import com.demonwav.mcdev.platform.mixin.inspection.injector.MethodSignature
+import com.demonwav.mcdev.platform.mixin.inspection.injector.ParameterGroup
+import com.demonwav.mcdev.platform.mixin.util.LocalVariables
+import com.demonwav.mcdev.platform.mixin.util.hasAccess
+import com.demonwav.mcdev.platform.mixin.util.toPsiType
+import com.demonwav.mcdev.util.computeStringArray
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.constantValue
+import com.demonwav.mcdev.util.descriptor
+import com.demonwav.mcdev.util.findContainingMethod
+import com.demonwav.mcdev.util.findModule
+import com.intellij.openapi.module.Module
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiType
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodNode
 
@@ -21,7 +40,159 @@ class ModifyVariableHandler : InjectorAnnotationHandler() {
         targetClass: ClassNode,
         targetMethod: MethodNode
     ): List<MethodSignature>? {
-        // TODO: implement properly
-        return null
+        val module = annotation.findModule() ?: return null
+
+        val at = annotation.findAttributeValue("at") as? PsiAnnotation
+        val atCode = at?.findAttributeValue("value")?.constantStringValue
+        val isLoadStore = atCode != null && InjectionPoint.byAtCode(atCode) is AbstractLoadInjectionPoint
+        val mode = if (isLoadStore) CollectVisitor.Mode.COMPLETION else CollectVisitor.Mode.MATCH_ALL
+        val targets = resolveInstructions(annotation, targetClass, targetMethod, mode)
+
+        val targetParamsGroup = ParameterGroup(
+            collectTargetMethodParameters(annotation.project, targetClass, targetMethod),
+            required = ParameterGroup.RequiredLevel.OPTIONAL,
+            isVarargs = true
+        )
+
+        val info = ModifyVariableInfo.getModifyVariableInfo(annotation, CollectVisitor.Mode.COMPLETION)
+            ?: return null
+
+        val possibleTypes = mutableSetOf<String>()
+        for (insn in targets) {
+            val locals = info.getLocals(module, targetClass, targetMethod, insn.insn) ?: continue
+            val matchedLocals = info.matchLocals(locals, CollectVisitor.Mode.COMPLETION, matchType = false)
+            for (local in matchedLocals) {
+                possibleTypes += local.desc!!
+            }
+        }
+
+        val result = mutableListOf<MethodSignature>()
+
+        val elementFactory = JavaPsiFacade.getElementFactory(annotation.project)
+        for (type in possibleTypes) {
+            val psiType = Type.getType(type).toPsiType(elementFactory)
+            result += MethodSignature(
+                listOf(
+                    ParameterGroup(listOf(sanitizedParameter(psiType, "value"))),
+                    targetParamsGroup
+                ),
+                psiType
+            )
+        }
+
+        return result
+    }
+}
+
+class ModifyVariableInfo(
+    val type: PsiType?,
+    val argsOnly: Boolean,
+    val index: Int?,
+    val ordinal: Int?,
+    val names: Set<String>
+) {
+    fun getLocals(
+        module: Module,
+        targetClass: ClassNode,
+        methodNode: MethodNode,
+        insn: AbstractInsnNode
+    ): Array<LocalVariables.LocalVariable?>? {
+        return if (argsOnly) {
+            val args = mutableListOf<LocalVariables.LocalVariable?>()
+            if (!methodNode.hasAccess(Opcodes.ACC_STATIC)) {
+                val thisDesc = Type.getObjectType(targetClass.name).descriptor
+                args.add(LocalVariables.LocalVariable("this", thisDesc, null, null, null, 0))
+            }
+            for (argType in Type.getArgumentTypes(methodNode.desc)) {
+                args.add(
+                    LocalVariables.LocalVariable("arg${args.size}", argType.descriptor, null, null, null, args.size)
+                )
+                if (argType.size == 2) {
+                    args.add(null)
+                }
+            }
+            args.toTypedArray()
+        } else {
+            LocalVariables.getLocals(module, targetClass, methodNode, insn)
+        }
+    }
+
+    fun matchLocals(
+        locals: Array<LocalVariables.LocalVariable?>,
+        mode: CollectVisitor.Mode,
+        matchType: Boolean = true
+    ): List<LocalVariables.LocalVariable> {
+        val typeDesc = type?.descriptor
+        if (ordinal != null) {
+            val ordinals = mutableMapOf<String, Int>()
+            val result = mutableListOf<LocalVariables.LocalVariable>()
+            for (local in locals) {
+                if (local == null) {
+                    continue
+                }
+                val ordinal = ordinals[local.desc] ?: 0
+                ordinals[local.desc!!] = ordinal + 1
+                if (ordinal == ordinal && (!matchType || typeDesc == null || local.desc == typeDesc)) {
+                    result += local
+                }
+            }
+            return result
+        }
+
+        if (index != null) {
+            val local = locals.firstOrNull { it?.index == index }
+            if (local != null) {
+                if (!matchType || typeDesc == null || local.desc == typeDesc) {
+                    return listOf(local)
+                }
+            }
+            return emptyList()
+        }
+
+        if (names.isNotEmpty()) {
+            val result = mutableListOf<LocalVariables.LocalVariable>()
+            for (local in locals) {
+                if (local == null) {
+                    continue
+                }
+                if (names.contains(local.name)) {
+                    if (!matchType || typeDesc == null || local.desc == typeDesc) {
+                        result += local
+                    }
+                }
+            }
+            return result
+        }
+
+        // implicit mode
+        if (mode == CollectVisitor.Mode.COMPLETION) {
+            return locals.asSequence()
+                .filterNotNull()
+                .filter { local -> locals.count { it?.desc == local.desc } == 1 }
+                .toList()
+        }
+
+        return if (matchType && typeDesc != null) {
+            locals.singleOrNull { it?.desc == typeDesc }?.let { listOf(it) } ?: emptyList()
+        } else {
+            emptyList()
+        }
+    }
+
+    companion object {
+        fun getModifyVariableInfo(modifyVariable: PsiAnnotation, mode: CollectVisitor.Mode?): ModifyVariableInfo? {
+            val method = modifyVariable.findContainingMethod() ?: return null
+            val type = method.parameterList.getParameter(0)?.type
+            if (type == null && mode != CollectVisitor.Mode.COMPLETION) {
+                return null
+            }
+            val argsOnly = modifyVariable.findDeclaredAttributeValue("argsOnly")?.constantValue as? Boolean ?: false
+            val index = (modifyVariable.findDeclaredAttributeValue("index")?.constantValue as? Int)
+                ?.takeIf { it != -1 }
+            val ordinal = (modifyVariable.findDeclaredAttributeValue("ordinal")?.constantValue as? Int)
+                ?.takeIf { it != -1 }
+            val names = modifyVariable.findDeclaredAttributeValue("name")?.computeStringArray()?.toSet() ?: emptySet()
+            return ModifyVariableInfo(type, argsOnly, index, ordinal, names)
+        }
     }
 }

--- a/src/main/kotlin/platform/mixin/handlers/RedirectInjectorHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/RedirectInjectorHandler.kt
@@ -84,7 +84,8 @@ class RedirectInjectorHandler : InjectorAnnotationHandler() {
             // add a parameter group for capturing the target method parameters
             val extraGroup = ParameterGroup(
                 collectTargetMethodParameters(annotation.project, targetClass, targetMethod),
-                required = false
+                required = ParameterGroup.RequiredLevel.OPTIONAL,
+                isVarargs = true
             )
             MethodSignature(paramGroups + extraGroup, returnType)
         }
@@ -385,7 +386,7 @@ class RedirectInjectorHandler : InjectorAnnotationHandler() {
                 }
             ).map { (paramGroups, _) ->
                 // drop the instance parameter, return the constructed type
-                MethodSignature(listOf(ParameterGroup(paramGroups[0].parameters?.drop(1))), constructedType)
+                MethodSignature(listOf(ParameterGroup(paramGroups[0].parameters.drop(1))), constructedType)
             }
         }
     }

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/AtResolver.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/AtResolver.kt
@@ -121,16 +121,16 @@ class AtResolver(
         }
     }
 
-    fun resolveInstructions(): List<CollectVisitor.Result<*>> {
-        return (getInstructionResolutionInfo() as? InsnResolutionInfo.Success)?.results ?: emptyList()
+    fun resolveInstructions(mode: CollectVisitor.Mode = CollectVisitor.Mode.MATCH_ALL): List<CollectVisitor.Result<*>> {
+        return (getInstructionResolutionInfo(mode) as? InsnResolutionInfo.Success)?.results ?: emptyList()
     }
 
-    fun getInstructionResolutionInfo(): InsnResolutionInfo {
+    fun getInstructionResolutionInfo(mode: CollectVisitor.Mode = CollectVisitor.Mode.MATCH_ALL): InsnResolutionInfo {
         val injectionPoint = getInjectionPoint(at) ?: return InsnResolutionInfo.Failure()
         val targetAttr = at.findAttributeValue("target")
         val target = targetAttr?.let { parseMixinSelector(it) }
 
-        val collectVisitor = injectionPoint.createCollectVisitor(at, target, targetClass, CollectVisitor.Mode.MATCH_ALL)
+        val collectVisitor = injectionPoint.createCollectVisitor(at, target, targetClass, mode)
             ?: return InsnResolutionInfo.Failure()
         collectVisitor.visit(targetMethod)
         val result = collectVisitor.result

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/LoadInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/LoadInjectionPoint.kt
@@ -132,7 +132,7 @@ abstract class AbstractLoadInjectionPoint(private val store: Boolean) : Injectio
                             ) &&
                         PsiUtil.isConstantExpression(parentExpr.rExpression) &&
                         (parentExpr.rExpression?.constantValue as? Number)?.toInt()
-                        ?.let { it >= -128 && it <= 127 } == true
+                        ?.let { it >= Short.MIN_VALUE && it <= Short.MAX_VALUE } == true
                     val isIinc = isIincUnary || isIincAssignment
                     if (isIinc) {
                         if (store) {
@@ -161,7 +161,10 @@ abstract class AbstractLoadInjectionPoint(private val store: Boolean) : Injectio
 
         private fun checkImplicitLocalsPre(location: PsiElement) {
             val localsHere = LocalVariables.guessLocalsAt(location, info.argsOnly, true)
-            for (local in localsHere) {
+            val localIndex = LocalVariables.guessLocalVariableIndex(location) ?: return
+            val localCount = LocalVariables.getLocalVariableSize(location)
+            for (i in localIndex until (localIndex + localCount)) {
+                val local = localsHere.firstOrNull { it.index == i } ?: continue
                 if (store) {
                     repeat(local.implicitStoreCountBefore) {
                         addLocalUsage(location, local.name, localsHere)
@@ -176,7 +179,10 @@ abstract class AbstractLoadInjectionPoint(private val store: Boolean) : Injectio
 
         private fun checkImplicitLocalsPost(location: PsiElement) {
             val localsHere = LocalVariables.guessLocalsAt(location, info.argsOnly, false)
-            for (local in localsHere) {
+            val localIndex = LocalVariables.guessLocalVariableIndex(location) ?: return
+            val localCount = LocalVariables.getLocalVariableSize(location)
+            for (i in localIndex until (localIndex + localCount)) {
+                val local = localsHere.firstOrNull { it.index == i } ?: continue
                 if (store) {
                     repeat(local.implicitStoreCountAfter) {
                         addLocalUsage(location, local.name, localsHere)

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/LoadInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/LoadInjectionPoint.kt
@@ -1,0 +1,295 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.handlers.injectionPoint
+
+import com.demonwav.mcdev.platform.mixin.handlers.ModifyVariableInfo
+import com.demonwav.mcdev.platform.mixin.reference.MixinSelector
+import com.demonwav.mcdev.platform.mixin.util.LocalVariables
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MODIFY_VARIABLE
+import com.demonwav.mcdev.util.constantValue
+import com.demonwav.mcdev.util.findModule
+import com.demonwav.mcdev.util.isErasureEquivalentTo
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.module.Module
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.JavaTokenType
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAssignmentExpression
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpressionStatement
+import com.intellij.psi.PsiForeachStatement
+import com.intellij.psi.PsiParameter
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.PsiThisExpression
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiUnaryExpression
+import com.intellij.psi.PsiVariable
+import com.intellij.psi.util.PsiUtil
+import com.intellij.psi.util.parentOfType
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.MethodNode
+import org.objectweb.asm.tree.VarInsnNode
+
+abstract class AbstractLoadInjectionPoint(private val store: Boolean) : InjectionPoint<PsiElement>() {
+    private fun getModifyVariableInfo(at: PsiAnnotation, mode: CollectVisitor.Mode?): ModifyVariableInfo? {
+        val modifyVariable = at.parentOfType<PsiAnnotation>() ?: return null
+        if (!modifyVariable.hasQualifiedName(MODIFY_VARIABLE)) {
+            return null
+        }
+        return ModifyVariableInfo.getModifyVariableInfo(modifyVariable, mode)
+    }
+
+    override fun createNavigationVisitor(
+        at: PsiAnnotation,
+        target: MixinSelector?,
+        targetClass: PsiClass
+    ): NavigationVisitor? {
+        val info = getModifyVariableInfo(at, null) ?: return null
+        return MyNavigationVisitor(info, store)
+    }
+
+    override fun doCreateCollectVisitor(
+        at: PsiAnnotation,
+        target: MixinSelector?,
+        targetClass: ClassNode,
+        mode: CollectVisitor.Mode
+    ): CollectVisitor<PsiElement>? {
+        val module = at.findModule() ?: return null
+        val info = getModifyVariableInfo(at, mode) ?: return null
+        return MyCollectVisitor(module, targetClass, mode, info, store)
+    }
+
+    override fun createLookup(
+        targetClass: ClassNode,
+        result: CollectVisitor.Result<PsiElement>
+    ): LookupElementBuilder? {
+        return null
+    }
+
+    private class MyNavigationVisitor(
+        private val info: ModifyVariableInfo,
+        private val store: Boolean
+    ) : NavigationVisitor() {
+        override fun visitThisExpression(expression: PsiThisExpression) {
+            super.visitThisExpression(expression)
+            if (!store && expression.qualifier == null) {
+                addLocalUsage(expression, "this")
+            }
+        }
+
+        override fun visitVariable(variable: PsiVariable) {
+            super.visitVariable(variable)
+            if (store && variable.initializer != null) {
+                val name = variable.name
+                if (name != null) {
+                    addLocalUsage(variable, name)
+                }
+            }
+        }
+
+        override fun visitReferenceExpression(expression: PsiReferenceExpression) {
+            super.visitReferenceExpression(expression)
+            val referenceName = expression.referenceName ?: return
+            if (expression.qualifierExpression == null) {
+                val isCorrectAccessType = if (store) {
+                    PsiUtil.isAccessedForWriting(expression)
+                } else {
+                    PsiUtil.isAccessedForReading(expression)
+                }
+                if (!isCorrectAccessType) {
+                    return
+                }
+                val resolved = expression.resolve() as? PsiVariable ?: return
+                val type = resolved.type
+                if (type is PsiPrimitiveType &&
+                    type != PsiType.FLOAT &&
+                    type != PsiType.DOUBLE &&
+                    type != PsiType.LONG &&
+                    type != PsiType.BOOLEAN
+                ) {
+                    // ModifyVariable currently cannot handle iinc
+                    val parentExpr = PsiUtil.skipParenthesizedExprUp(expression.parent)
+                    val isIincUnary = parentExpr is PsiUnaryExpression &&
+                        (
+                            parentExpr.operationSign.tokenType == JavaTokenType.PLUSPLUS ||
+                                parentExpr.operationSign.tokenType == JavaTokenType.MINUSMINUS
+                            )
+                    val isIincAssignment = parentExpr is PsiAssignmentExpression &&
+                        (
+                            parentExpr.operationSign.tokenType == JavaTokenType.PLUSEQ ||
+                                parentExpr.operationSign.tokenType == JavaTokenType.MINUSEQ
+                            ) &&
+                        PsiUtil.isConstantExpression(parentExpr.rExpression) &&
+                        (parentExpr.rExpression?.constantValue as? Number)?.toInt()
+                        ?.let { it >= -128 && it <= 127 } == true
+                    val isIinc = isIincUnary || isIincAssignment
+                    if (isIinc) {
+                        if (store) {
+                            return
+                        }
+                        val parentParent = PsiUtil.skipParenthesizedExprUp(parentExpr.parent)
+                        if (parentParent is PsiExpressionStatement) {
+                            return
+                        }
+                    }
+                }
+                if (!info.argsOnly || resolved is PsiParameter) {
+                    addLocalUsage(expression, referenceName)
+                }
+            }
+        }
+
+        override fun visitForeachStatement(statement: PsiForeachStatement) {
+            checkImplicitLocalsPre(statement)
+            if (store) {
+                addLocalUsage(statement.iterationParameter, statement.iterationParameter.name)
+            }
+            super.visitForeachStatement(statement)
+            checkImplicitLocalsPost(statement)
+        }
+
+        private fun checkImplicitLocalsPre(location: PsiElement) {
+            val localsHere = LocalVariables.guessLocalsAt(location, info.argsOnly, true)
+            for (local in localsHere) {
+                if (store) {
+                    repeat(local.implicitStoreCountBefore) {
+                        addLocalUsage(location, local.name, localsHere)
+                    }
+                } else {
+                    repeat(local.implicitLoadCountBefore) {
+                        addLocalUsage(location, local.name, localsHere)
+                    }
+                }
+            }
+        }
+
+        private fun checkImplicitLocalsPost(location: PsiElement) {
+            val localsHere = LocalVariables.guessLocalsAt(location, info.argsOnly, false)
+            for (local in localsHere) {
+                if (store) {
+                    repeat(local.implicitStoreCountAfter) {
+                        addLocalUsage(location, local.name, localsHere)
+                    }
+                } else {
+                    repeat(local.implicitLoadCountAfter) {
+                        addLocalUsage(location, local.name, localsHere)
+                    }
+                }
+            }
+        }
+
+        private fun addLocalUsage(location: PsiElement, name: String) {
+            val localsHere = LocalVariables.guessLocalsAt(location, info.argsOnly, !store)
+            addLocalUsage(location, name, localsHere)
+        }
+
+        private fun addLocalUsage(
+            location: PsiElement,
+            name: String,
+            localsHere: List<LocalVariables.SourceLocalVariable>
+        ) {
+            if (info.ordinal != null) {
+                val local = localsHere.asSequence().filter {
+                    it.type.isErasureEquivalentTo(info.type)
+                }.drop(info.ordinal).firstOrNull()
+                if (name == local?.name) {
+                    addResult(location)
+                }
+                return
+            }
+
+            if (info.index != null) {
+                val local = localsHere.getOrNull(info.index)
+                if (name == local?.name) {
+                    addResult(location)
+                }
+                return
+            }
+
+            if (info.names.isNotEmpty()) {
+                val matchingLocals = localsHere.filter {
+                    info.names.contains(it.mixinName)
+                }
+                for (local in matchingLocals) {
+                    if (local.name == name) {
+                        addResult(location)
+                    }
+                }
+                return
+            }
+
+            // implicit mode
+            val local = localsHere.singleOrNull {
+                it.type.isErasureEquivalentTo(info.type)
+            }
+            if (local != null && local.name == name) {
+                addResult(location)
+            }
+        }
+    }
+
+    private class MyCollectVisitor(
+        private val module: Module,
+        private val targetClass: ClassNode,
+        mode: Mode,
+        private val info: ModifyVariableInfo,
+        private val store: Boolean
+    ) : CollectVisitor<PsiElement>(mode) {
+        override fun accept(methodNode: MethodNode) {
+            var opcode = when (info.type) {
+                null -> null
+                !is PsiPrimitiveType -> Opcodes.ALOAD
+                PsiType.LONG -> Opcodes.LLOAD
+                PsiType.FLOAT -> Opcodes.FLOAD
+                PsiType.DOUBLE -> Opcodes.DLOAD
+                else -> Opcodes.ILOAD
+            }
+            if (store && opcode != null) {
+                opcode += (Opcodes.ISTORE - Opcodes.ILOAD)
+            }
+            for (insn in methodNode.instructions) {
+                if (insn !is VarInsnNode) {
+                    continue
+                }
+                if (opcode != null) {
+                    if (opcode != insn.opcode) {
+                        continue
+                    }
+                } else {
+                    if (store) {
+                        if (insn.opcode < Opcodes.ISTORE || insn.opcode > Opcodes.ASTORE) {
+                            continue
+                        }
+                    } else {
+                        if (insn.opcode < Opcodes.ILOAD || insn.opcode > Opcodes.ALOAD) {
+                            continue
+                        }
+                    }
+                }
+
+                val localLocation = if (store) insn.next ?: insn else insn
+                val locals = info.getLocals(module, targetClass, methodNode, localLocation) ?: continue
+
+                val elementFactory = JavaPsiFacade.getElementFactory(module.project)
+
+                for (result in info.matchLocals(locals, mode)) {
+                    addResult(insn, elementFactory.createExpressionFromText(result.name, null))
+                }
+            }
+        }
+    }
+}
+
+class LoadInjectionPoint : AbstractLoadInjectionPoint(false)
+class StoreInjectionPoint : AbstractLoadInjectionPoint(true)

--- a/src/main/kotlin/util/psi-utils.kt
+++ b/src/main/kotlin/util/psi-utils.kt
@@ -29,6 +29,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiEllipsisType
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiKeyword
 import com.intellij.psi.PsiMember
@@ -46,6 +47,7 @@ import com.intellij.psi.filters.ElementFilter
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.PsiTypesUtil
 import com.intellij.psi.util.TypeConversionUtil
 import com.intellij.refactoring.changeSignature.ChangeSignatureUtil
 import com.siyeh.ig.psiutils.ImportUtils
@@ -181,8 +183,15 @@ infix fun PsiElement.equivalentTo(other: PsiElement): Boolean {
 }
 
 fun PsiType?.isErasureEquivalentTo(other: PsiType?): Boolean {
-    // TODO: Do more checks for generics instead
-    return TypeConversionUtil.erasure(this) == TypeConversionUtil.erasure(other)
+    return this?.normalize() == other?.normalize()
+}
+
+fun PsiType.normalize(): PsiType {
+    var normalized = TypeConversionUtil.erasure(this)
+    if (normalized is PsiEllipsisType) {
+        normalized = normalized.toArrayType()
+    }
+    return normalized
 }
 
 val PsiMethod.nameAndParameterTypes: String
@@ -249,3 +258,6 @@ val PsiMethodReferenceExpression.hasSyntheticMethod: Boolean
         if (qualifier !is PsiReferenceExpression) return true
         return qualifier.resolve() !is PsiClass
     }
+
+val PsiClass.psiType: PsiType
+    get() = PsiTypesUtil.getClassType(this)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -71,7 +71,9 @@
         <injectionPoint atCode="HEAD" implementation="com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.HeadInjectionPoint" />
         <injectionPoint atCode="RETURN" implementation="com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.ReturnInjectionPoint" />
         <injectionPoint atCode="TAIL" implementation="com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.TailInjectionPoint" />
-        <!-- TODO: LOAD, STORE, CONSTANT -->
+        <injectionPoint atCode="LOAD" implementation="com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.LoadInjectionPoint" />
+        <injectionPoint atCode="STORE" implementation="com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.StoreInjectionPoint" />
+        <!-- TODO: CONSTANT -->
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Adds support for `@ModifyVariable` signature inspections.
Also tweaks the way signature matching works, which allows for incorrect local variables to be a warning rather than an error for `@Inject`'s `CAPTURE_FAILSOFT`.