### PR TITLE
Use papermc repo for waterfall

### DIFF
--- a/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectCreator.kt
+++ b/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectCreator.kt
@@ -152,8 +152,8 @@ class BungeeCordDependenciesStep(
             PlatformType.WATERFALL -> {
                 buildSystem.repositories.add(
                     BuildRepository(
-                        "destroystokyo-repo",
-                        "https://repo.destroystokyo.com/repository/maven-public/"
+                        "papermc-repo",
+                        "https://papermc.io/repo/repository/maven-public/"
                     )
                 )
                 buildSystem.dependencies.add(


### PR DESCRIPTION
The destroystokyo.com domain isn't used anymore, requests to repo.destroystokyo.com redirect to papermc.io/repo. Since the Waterfall README also references this repo, and no versions seem to be missing (which wouldn't really make sense since the old repo redirects here anyway), there isn't really any reason to use the old repo.