### PR TITLE
Update Gradle to 7.3.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
+++ b/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
@@ -87,7 +87,7 @@ class GradleBuildSystem(
     }
 
     companion object {
-        val DEFAULT_WRAPPER_VERSION = SemanticVersion.release(7, 3)
+        val DEFAULT_WRAPPER_VERSION = SemanticVersion.release(7, 3, 3)
     }
 }
 


### PR DESCRIPTION
Updates Gradle to version 7.3.3 for MCDev itself and Gradle projects created using it.

Gradle 7.3.2 and 7.3.3 are both Log4J-related security releases. Although MCDev doesn't
seem to be directly affected by this vulnerability, projects created using MCDev might be.