### PR TITLE
Fix #1782 and add inspection for wrong entity data parameters

### DIFF
--- a/src/main/kotlin/inspection/WrongEntityDataParameterClassInspection.kt
+++ b/src/main/kotlin/inspection/WrongEntityDataParameterClassInspection.kt
@@ -1,0 +1,93 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2021 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.inspection
+
+import com.demonwav.mcdev.util.findContainingClass
+import com.demonwav.mcdev.util.fullQualifiedName
+import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.util.InheritanceUtil
+
+class WrongEntityDataParameterClassInspection : AbstractBaseJavaLocalInspectionTool() {
+
+    override fun getStaticDescription() = "Reports when the class passed to an entity data parameter definition is not the same as the containing entity class"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = Visitor(holder)
+
+    class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+        override fun visitMethodCallExpression(expression: PsiMethodCallExpression?) {
+            super.visitMethodCallExpression(expression)
+            if (expression == null) {
+                return
+            }
+
+            val method = expression.resolveMethod() ?: return
+            val className = method.containingClass?.fullQualifiedName ?: return
+            val methodName = method.name
+
+            if (className !in ENTITY_DATA_MANAGER_CLASSES || methodName !in DEFINE_ID_METHODS) return
+
+            val containingClass = expression.findContainingClass() ?: return
+
+            if (!isEntitySubclass(containingClass)) return
+
+            val firstParameter = expression.argumentList.expressions.firstOrNull() ?: return
+            val firstParameterGenericsClass = ((firstParameter.type as? PsiClassType)?.parameters?.firstOrNull() as? PsiClassType)?.resolve() ?: return
+
+            if (!containingClass.manager.areElementsEquivalent(containingClass, firstParameterGenericsClass))
+                holder.registerProblem(expression, "Entity class does not match this entity class", QuickFix(containingClass, expression, firstParameter))
+        }
+    }
+
+    private class QuickFix(
+        private val containingClass: PsiClass,
+        private val expression: PsiMethodCallExpression,
+        private val firstParameter: PsiExpression
+    ) : LocalQuickFix {
+        override fun getName() = "Replace other entity class with this entity class"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val factory = JavaPsiFacade.getElementFactory(project)
+            firstParameter.replace(factory.createExpressionFromText("${containingClass.name}.class", firstParameter))
+        }
+
+        override fun getFamilyName() = name
+    }
+
+    companion object {
+        private val ENTITY_CLASSES = setOf(
+            "net.minecraft.entity.Entity",
+            "net.minecraft.world.entity.Entity",
+        )
+        private val ENTITY_DATA_MANAGER_CLASSES = setOf(
+            "net.minecraft.network.datasync.EntityDataManager",
+            "net.minecraft.network.syncher.SynchedEntityData",
+            "net.minecraft.entity.data.DataTracker"
+        )
+        private val DEFINE_ID_METHODS = setOf(
+            "defineId",
+            "createKey",
+            "registerData"
+        )
+
+        private fun isEntitySubclass(clazz: PsiClass): Boolean = InheritanceUtil.getSuperClasses(clazz).any { it.qualifiedName in ENTITY_CLASSES }
+    }
+}

--- a/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
@@ -156,9 +156,10 @@ abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
             targetMethod: MethodNode
         ): List<Parameter> {
             val numLocalsToDrop = if (targetMethod.hasAccess(Opcodes.ACC_STATIC)) 0 else 1
+            val localVariables = targetMethod.localVariables?.sortedBy { it.index }
             return targetMethod.getGenericParameterTypes(clazz, project).asSequence().withIndex()
                 .map { (index, type) ->
-                    val name = targetMethod.localVariables
+                    val name = localVariables
                         ?.getOrNull(index + numLocalsToDrop)
                         ?.name
                         ?.toJavaIdentifier()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -399,6 +399,13 @@
                          level="WARNING"
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.translations.inspections.SuperfluousFormatInspection"/>
+        <localInspection displayName="Entity class does not match this entity class"
+                         groupName="Minecraft"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.inspection.WrongEntityDataParameterClassInspection"/>
         <!--endregion-->
 
         <!--region BUKKIT INSPECTIONS-->


### PR DESCRIPTION
This PR does two unrelated things:
* Adds an inspection for entity data parameters that are defined with the wrong class. This is easy to mess up during copy/pasting of definitions from other mods / vanilla and leads to hard-to-find syncing bugs. Currently supports MCP, Mojmap, and Yarn mappings.
* Fixes #1782 by sorting target parameters by index, see related comment [here](https://github.com/minecraft-dev/MinecraftDev/issues/1782#issuecomment-1012808423).

Demo of new inspection:
<details open>
<summary>DemoEntity class before and after (Forge 1.18.1)</summary>

### Before

```java
public abstract class DemoEntity extends Entity {
    public static final EntityDataAccessor<Integer> EXAMPLE_ID = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.INT);

    public DemoEntity(EntityType<?> entityType, Level level) {
        super(entityType, level);
    }
}
```

### After

```java
public abstract class DemoEntity extends Entity {
    public static final EntityDataAccessor<Integer> EXAMPLE_ID = SynchedEntityData.defineId(DemoEntity.class, EntityDataSerializers.INT);

    public DemoEntity(EntityType<?> entityType, Level level) {
        super(entityType, level);
    }
}
```

</details>
<details open>
<summary>Screenshots</summary>

![screenshot 1](https://i.imgur.com/LFwi9Kc.png)

</details>
