### PR TITLE
Remove multi module creators

### DIFF
--- a/src/main/kotlin/creator/BuildSystemWizardStep.kt
+++ b/src/main/kotlin/creator/BuildSystemWizardStep.kt
@@ -39,8 +39,10 @@ class BuildSystemWizardStep(private val creator: MinecraftProjectCreator) : Modu
         buildSystemBox.removeAllItems()
         buildSystemBox.isEnabled = true
 
+        val creatorConfig = creator.config ?: return
+
         val types = BuildSystemType.values().filter { type ->
-            creator.configs.all { type.creatorType.isInstance(it) }
+            type.creatorType.isInstance(creatorConfig)
         }
 
         for (type in types) {
@@ -59,26 +61,7 @@ class BuildSystemWizardStep(private val creator: MinecraftProjectCreator) : Modu
 
         buildSystemBox.selectedIndex = 0
 
-        // We prefer Gradle, so if it's included, choose it
-        // If Gradle is not included, luck of the draw
-        if (creator.configs.any { it.preferredBuildSystem == BuildSystemType.GRADLE }) {
-            buildSystemBox.selectedItem = BuildSystemType.GRADLE
-            return
-        }
-
-        val counts = creator.configs.asSequence()
-            .mapNotNull { it.preferredBuildSystem }
-            .groupingBy { it }
-            .eachCount()
-
-        val maxValue = counts.maxByOrNull { it.value }?.value ?: return
-        counts.asSequence()
-            .filter { it.value == maxValue }
-            .map { it.key }
-            .firstOrNull()
-            ?.let { mostPopularType ->
-                buildSystemBox.selectedItem = mostPopularType
-            }
+        creatorConfig.preferredBuildSystem?.let { buildSystemBox.selectedItem = it }
     }
 
     override fun updateDataModel() {

--- a/src/main/kotlin/creator/MinecraftModuleWizardStep.kt
+++ b/src/main/kotlin/creator/MinecraftModuleWizardStep.kt
@@ -66,14 +66,6 @@ abstract class MinecraftModuleWizardStep : ModuleWizardStep() {
         val name = WordUtils.capitalize(buildSystem.artifactId.replace('-', ' '))
         pluginNameField.text = name
 
-        if (creator.configs.indexOf(config) != 0) {
-            pluginNameField.isEditable = false
-        }
-
         mainClassField.text = generateClassName(buildSystem, name)
-
-        if (creator.configs.size > 1) {
-            mainClassField.text = mainClassField.text + config.type.normalName
-        }
     }
 }

--- a/src/main/kotlin/creator/ProjectChooserWizardStep.form
+++ b/src/main/kotlin/creator/ProjectChooserWizardStep.form
@@ -28,7 +28,7 @@
         <properties/>
         <border type="empty"/>
         <children>
-          <grid id="c580e" binding="chooserPanel" layout-manager="GridLayoutManager" row-count="12" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="5" vgap="5">
+          <grid id="c580e" layout-manager="GridLayoutManager" row-count="12" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="5" vgap="5">
             <margin top="2" left="10" bottom="10" right="10"/>
             <constraints/>
             <properties/>
@@ -98,7 +98,7 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="1a539" class="javax.swing.JCheckBox" binding="bukkitPluginCheckBox" default-binding="true">
+              <component id="1a539" class="com.intellij.ui.components.JBRadioButton" binding="bukkitPluginButton">
                 <constraints>
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -106,7 +106,7 @@
                   <text value="Bukkit Plugin"/>
                 </properties>
               </component>
-              <component id="1a691" class="javax.swing.JCheckBox" binding="spigotPluginCheckBox" default-binding="true">
+              <component id="1a691" class="com.intellij.ui.components.JBRadioButton" binding="spigotPluginButton">
                 <constraints>
                   <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -114,7 +114,7 @@
                   <text value="Spigot Plugin"/>
                 </properties>
               </component>
-              <component id="24d89" class="javax.swing.JCheckBox" binding="paperPluginCheckBox">
+              <component id="24d89" class="com.intellij.ui.components.JBRadioButton" binding="paperPluginButton">
                 <constraints>
                   <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -122,7 +122,7 @@
                   <text value="Paper Plugin"/>
                 </properties>
               </component>
-              <component id="657b2" class="javax.swing.JCheckBox" binding="spongePluginCheckBox">
+              <component id="657b2" class="com.intellij.ui.components.JBRadioButton" binding="spongePluginButton">
                 <constraints>
                   <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -130,7 +130,7 @@
                   <text value="Sponge Plugin"/>
                 </properties>
               </component>
-              <component id="d9577" class="javax.swing.JCheckBox" binding="forgeModCheckBox">
+              <component id="d9577" class="com.intellij.ui.components.JBRadioButton" binding="forgeModButton">
                 <constraints>
                   <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -138,7 +138,7 @@
                   <text value="Forge Mod"/>
                 </properties>
               </component>
-              <component id="51426" class="javax.swing.JCheckBox" binding="bungeeCordPluginCheckBox">
+              <component id="51426" class="com.intellij.ui.components.JBRadioButton" binding="bungeeCordPluginButton">
                 <constraints>
                   <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -155,7 +155,7 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="5a8c1" class="javax.swing.JCheckBox" binding="liteLoaderModCheckBox" default-binding="true">
+              <component id="5a8c1" class="com.intellij.ui.components.JBRadioButton" binding="liteLoaderModButton">
                 <constraints>
                   <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -185,7 +185,7 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="55507" class="javax.swing.JCheckBox" binding="waterfallPluginCheckBox">
+              <component id="55507" class="com.intellij.ui.components.JBRadioButton" binding="waterfallPluginButton">
                 <constraints>
                   <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -193,7 +193,7 @@
                   <text value="Waterfall Plugin"/>
                 </properties>
               </component>
-              <component id="93e0" class="javax.swing.JCheckBox" binding="velocityPluginCheckBox">
+              <component id="93e0" class="com.intellij.ui.components.JBRadioButton" binding="velocityPluginButton">
                 <constraints>
                   <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -215,7 +215,7 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="40b19" class="javax.swing.JCheckBox" binding="fabricModCheckBox">
+              <component id="40b19" class="com.intellij.ui.components.JBRadioButton" binding="fabricModButton">
                 <constraints>
                   <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -232,7 +232,7 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="d3acf" class="javax.swing.JCheckBox" binding="architecturyModCheckBox">
+              <component id="d3acf" class="com.intellij.ui.components.JBRadioButton" binding="architecturyModButton">
                 <constraints>
                   <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -247,7 +247,7 @@
     </children>
   </grid>
   <buttonGroups>
-    <group name="buttonGroup1">
+    <group name="projectButtons" bound="true">
       <member id="dd3ac"/>
       <member id="46880"/>
       <member id="c6c2d"/>
@@ -258,6 +258,17 @@
       <member id="c6c2d"/>
       <member id="69a73"/>
       <member id="dd3ac"/>
+      <member id="1a539"/>
+      <member id="1a691"/>
+      <member id="24d89"/>
+      <member id="657b2"/>
+      <member id="d9577"/>
+      <member id="51426"/>
+      <member id="5a8c1"/>
+      <member id="55507"/>
+      <member id="93e0"/>
+      <member id="40b19"/>
+      <member id="d3acf"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/main/kotlin/creator/ProjectCreator.kt
+++ b/src/main/kotlin/creator/ProjectCreator.kt
@@ -12,7 +12,6 @@ package com.demonwav.mcdev.creator
 
 import com.demonwav.mcdev.creator.buildsystem.BuildSystem
 import com.intellij.openapi.module.Module
-import java.nio.file.Path
 
 /**
  * This class represents a specific configuration for a project to be created. Typically these configurations represent
@@ -35,13 +34,7 @@ interface ProjectCreator {
      * Returns the [CreatorStep]s which should be executed in order to create the project configuration represented by
      * this [ProjectCreator].
      */
-    fun getSingleModuleSteps(): Iterable<CreatorStep>
-
-    /**
-     * Returns the [CreatorStep]s which should be executed in order to create the submodule project configuration
-     * represented by this [ProjectCreator].
-     */
-    fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep>
+    fun getSteps(): Iterable<CreatorStep>
 }
 
 typealias JavaClassTextMapper = (packageName: String, className: String) -> String
@@ -68,17 +61,4 @@ abstract class BaseProjectCreator(
         val packageName = text.substring(0, index)
         return packageName to className
     }
-}
-
-/**
- * Implement this interface on your [ProjectCreator] if you need to do extra setup work after all modules are built
- * and the project is imported, e.g. if some of the creation needs to be done in smart mode. Only gets used in
- * multi-project builds; single-module builds are expected to run these tasks themselves in the correct order, such
- * that they happen after the project is imported.
- *
- * Note: just because this interface can be used to utilize smart mode, doesn't mean that the steps will be called in
- * smart mode. If a step needs smart mode, it should wait for it itself.
- */
-interface PostMultiModuleAware {
-    fun getPostMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep>
 }

--- a/src/main/kotlin/creator/buildsystem/BuildSystem.kt
+++ b/src/main/kotlin/creator/buildsystem/BuildSystem.kt
@@ -11,6 +11,7 @@
 package com.demonwav.mcdev.creator.buildsystem
 
 import com.demonwav.mcdev.creator.CreatorStep
+import com.demonwav.mcdev.creator.ProjectConfig
 import com.demonwav.mcdev.creator.ProjectCreator
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleBuildSystem
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleCreator
@@ -37,7 +38,7 @@ abstract class BuildSystem(
     abstract val type: BuildSystemType
 
     abstract fun buildCreator(obj: Any, rootDirectory: Path, module: Module): ProjectCreator
-    open fun configure(list: Collection<Any>, rootDirectory: Path) {}
+    open fun configure(config: ProjectConfig, rootDirectory: Path) {}
 
     var repositories: MutableList<BuildRepository> = mutableListOf()
     var dependencies: MutableList<BuildDependency> = mutableListOf()

--- a/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
+++ b/src/main/kotlin/creator/buildsystem/gradle/GradleBuildSystem.kt
@@ -12,6 +12,7 @@ package com.demonwav.mcdev.creator.buildsystem.gradle
 
 import com.demonwav.mcdev.creator.CreateDirectoriesStep
 import com.demonwav.mcdev.creator.CreatorStep
+import com.demonwav.mcdev.creator.ProjectConfig
 import com.demonwav.mcdev.creator.ProjectCreator
 import com.demonwav.mcdev.creator.buildsystem.BuildSystem
 import com.demonwav.mcdev.creator.buildsystem.BuildSystemTemplate
@@ -78,11 +79,9 @@ class GradleBuildSystem(
         return obj.buildGradleCreator(rootDirectory, module, this)
     }
 
-    override fun configure(list: Collection<Any>, rootDirectory: Path) {
-        for (obj in list) {
-            if (obj is GradleCreator) {
-                obj.configureRootGradle(rootDirectory, this)
-            }
+    override fun configure(config: ProjectConfig, rootDirectory: Path) {
+        if (config is GradleCreator) {
+            config.configureRootGradle(rootDirectory, this)
         }
     }
 

--- a/src/main/kotlin/creator/buildsystem/maven/MavenBuildSystem.kt
+++ b/src/main/kotlin/creator/buildsystem/maven/MavenBuildSystem.kt
@@ -12,6 +12,7 @@ package com.demonwav.mcdev.creator.buildsystem.maven
 
 import com.demonwav.mcdev.creator.CreateDirectoriesStep
 import com.demonwav.mcdev.creator.CreatorStep
+import com.demonwav.mcdev.creator.ProjectConfig
 import com.demonwav.mcdev.creator.ProjectCreator
 import com.demonwav.mcdev.creator.buildsystem.BuildSystem
 import com.demonwav.mcdev.creator.buildsystem.BuildSystemTemplate
@@ -88,11 +89,9 @@ class MavenBuildSystem(
         return obj.buildMavenCreator(rootDirectory, module, this)
     }
 
-    override fun configure(list: Collection<Any>, rootDirectory: Path) {
-        for (obj in list) {
-            if (obj is MavenCreator) {
-                obj.configureRootMaven(rootDirectory, this)
-            }
+    override fun configure(config: ProjectConfig, rootDirectory: Path) {
+        if (config is MavenCreator) {
+            config.configureRootMaven(rootDirectory, this)
         }
     }
 }

--- a/src/main/kotlin/platform/architectury/creator/ArchitecturyProjectCreator.kt
+++ b/src/main/kotlin/platform/architectury/creator/ArchitecturyProjectCreator.kt
@@ -14,7 +14,6 @@ import com.demonwav.mcdev.creator.BaseProjectCreator
 import com.demonwav.mcdev.creator.BasicJavaClassStep
 import com.demonwav.mcdev.creator.CreateDirectoriesStep
 import com.demonwav.mcdev.creator.CreatorStep
-import com.demonwav.mcdev.creator.PostMultiModuleAware
 import com.demonwav.mcdev.creator.buildsystem.BuildSystem
 import com.demonwav.mcdev.creator.buildsystem.gradle.BasicGradleFinalizerStep
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleBuildSystem
@@ -51,7 +50,7 @@ class ArchitecturyProjectCreator(
     private val rootModule: Module,
     private val buildSystem: GradleBuildSystem,
     private val config: ArchitecturyProjectConfig
-) : BaseProjectCreator(rootModule, buildSystem), PostMultiModuleAware {
+) : BaseProjectCreator(rootModule, buildSystem) {
 
     private val commonModule: Module = project.runWriteTaskInSmartMode {
         ModuleManager.getInstance(rootModule.project)
@@ -66,26 +65,26 @@ class ArchitecturyProjectCreator(
             .newModule(rootDirectory.resolve("fabric"), ModuleType.get(rootModule).id)
     }
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val steps = mutableListOf<CreatorStep>()
         steps += ArchitecturyCommonProjectCreator(
             rootDirectory.resolve("common"),
             commonModule,
             buildSystem,
             config
-        ).getSingleModuleSteps()
+        ).getSteps()
         steps += ArchitecturyForgeProjectCreator(
             rootDirectory.resolve("forge"),
             forgeModule,
             buildSystem,
             config
-        ).getSingleModuleSteps()
+        ).getSteps()
         steps += ArchitecturyFabricProjectCreator(
             rootDirectory.resolve("fabric"),
             fabricModule,
             buildSystem,
             config
-        ).getSingleModuleSteps()
+        ).getSteps()
         steps += listOf(
             SimpleGradleSetupStep(
                 project,
@@ -104,47 +103,6 @@ class ArchitecturyProjectCreator(
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem)
         )
         return steps
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val steps = mutableListOf<CreatorStep>()
-        steps += ArchitecturyCommonProjectCreator(
-            rootDirectory.resolve("common"),
-            commonModule,
-            buildSystem,
-            config
-        ).getMultiModuleSteps(projectBaseDir)
-        steps += ArchitecturyForgeProjectCreator(
-            rootDirectory.resolve("forge"),
-            forgeModule,
-            buildSystem,
-            config
-        ).getMultiModuleSteps(projectBaseDir)
-        steps += ArchitecturyFabricProjectCreator(
-            rootDirectory.resolve("fabric"),
-            fabricModule,
-            buildSystem,
-            config
-        ).getMultiModuleSteps(projectBaseDir)
-        steps += listOf(
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                GradleFiles(
-                    ArchitecturyTemplate.applyMultiModuleBuildGradle(project, buildSystem, config),
-                    ArchitecturyTemplate.applyMultiModuleGradleProp(project, buildSystem, config),
-                    ArchitecturyTemplate.applySettingsGradle(project, buildSystem, config)
-                )
-            ),
-            GenRunsStep(project, rootDirectory),
-            CleanUpStep(rootDirectory)
-        )
-        return steps
-    }
-
-    override fun getPostMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        return listOf()
     }
 
     class GenRunsStep(
@@ -177,8 +135,8 @@ class ArchitecturyCommonProjectCreator(
     rootModule: Module,
     private val buildSystem: GradleBuildSystem,
     private val config: ArchitecturyProjectConfig
-) : BaseProjectCreator(rootModule, buildSystem), PostMultiModuleAware {
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+) : BaseProjectCreator(rootModule, buildSystem) {
+    override fun getSteps(): Iterable<CreatorStep> {
         return listOf(
             CreateDirectoriesStep(buildSystem, rootDirectory),
             ArchitecturyCommonMixinStep(project, buildSystem, config),
@@ -190,24 +148,6 @@ class ArchitecturyCommonProjectCreator(
             ),
             setupMainClassStep()
         )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        return listOf(
-            CreateDirectoriesStep(buildSystem, rootDirectory),
-            ArchitecturyCommonMixinStep(project, buildSystem, config),
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                GradleFiles(ArchitecturyTemplate.applyCommonBuildGradle(project, buildSystem, config), null, null)
-            ),
-            setupMainClassStep()
-        )
-    }
-
-    override fun getPostMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        return listOf()
     }
 
     private fun setupMainClassStep(): BasicJavaClassStep {
@@ -247,8 +187,8 @@ class ArchitecturyForgeProjectCreator(
     rootModule: Module,
     private val buildSystem: GradleBuildSystem,
     private val config: ArchitecturyProjectConfig
-) : BaseProjectCreator(rootModule, buildSystem), PostMultiModuleAware {
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+) : BaseProjectCreator(rootModule, buildSystem) {
+    override fun getSteps(): Iterable<CreatorStep> {
         return listOf(
             CreateDirectoriesStep(buildSystem, rootDirectory),
             ArchitecturyForgeMixinStep(project, buildSystem, config),
@@ -265,29 +205,6 @@ class ArchitecturyForgeProjectCreator(
             ),
             setupMainClassStep()
         )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        return listOf(
-            CreateDirectoriesStep(buildSystem, rootDirectory),
-            ArchitecturyForgeMixinStep(project, buildSystem, config),
-            ArchitecturyForgeResourcesStep(project, buildSystem, config),
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                GradleFiles(
-                    ArchitecturyTemplate.applyForgeBuildGradle(project, buildSystem, config),
-                    ArchitecturyTemplate.applyForgeGradleProp(project, buildSystem, config),
-                    null
-                )
-            ),
-            setupMainClassStep()
-        )
-    }
-
-    override fun getPostMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        return listOf()
     }
 
     private fun setupMainClassStep(): BasicJavaClassStep {
@@ -353,8 +270,8 @@ class ArchitecturyFabricProjectCreator(
     rootModule: Module,
     private val buildSystem: GradleBuildSystem,
     private val config: ArchitecturyProjectConfig
-) : BaseProjectCreator(rootModule, buildSystem), PostMultiModuleAware {
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+) : BaseProjectCreator(rootModule, buildSystem) {
+    override fun getSteps(): Iterable<CreatorStep> {
         return listOf(
             CreateDirectoriesStep(buildSystem, rootDirectory),
             ArchitecturyFabricMixinStep(project, buildSystem, config),
@@ -371,29 +288,6 @@ class ArchitecturyFabricProjectCreator(
             ),
             setupMainClassStep()
         )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        return listOf(
-            CreateDirectoriesStep(buildSystem, rootDirectory),
-            ArchitecturyFabricMixinStep(project, buildSystem, config),
-            ArchitecturyFabricResourcesStep(project, buildSystem, config),
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                GradleFiles(
-                    ArchitecturyTemplate.applyFabricBuildGradle(project, buildSystem, config),
-                    null,
-                    null
-                )
-            ),
-            setupMainClassStep()
-        )
-    }
-
-    override fun getPostMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        return listOf()
     }
 
     private fun setupMainClassStep(): BasicJavaClassStep {

--- a/src/main/kotlin/platform/architectury/creator/ArchitecturyProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/architectury/creator/ArchitecturyProjectSettingsWizard.kt
@@ -112,10 +112,6 @@ class ArchitecturyProjectSettingsWizard(private val creator: MinecraftProjectCre
         val (conf) = modUpdateStep<ArchitecturyProjectConfig>(creator, modNameField) ?: return
         config = conf
 
-        if (creator.configs.indexOf(conf) != 0) {
-            modNameField.isEditable = false
-        }
-
         title.icon = PlatformAssets.ARCHITECTURY_ICON_2X
         title.text = "<html><font size=\"5\">Architectury Settings</font></html>"
 
@@ -164,7 +160,7 @@ class ArchitecturyProjectSettingsWizard(private val creator: MinecraftProjectCre
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is ArchitecturyProjectConfig }
+        return creator.config is ArchitecturyProjectConfig
     }
 
     override fun onStepLeaving() {

--- a/src/main/kotlin/platform/bukkit/creator/BukkitProjectCreator.kt
+++ b/src/main/kotlin/platform/bukkit/creator/BukkitProjectCreator.kt
@@ -25,7 +25,6 @@ import com.demonwav.mcdev.creator.buildsystem.gradle.GradleSetupStep
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleWrapperStep
 import com.demonwav.mcdev.creator.buildsystem.maven.BasicMavenFinalizerStep
 import com.demonwav.mcdev.creator.buildsystem.maven.BasicMavenStep
-import com.demonwav.mcdev.creator.buildsystem.maven.CommonModuleDependencyStep
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenBuildSystem
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenGitignoreStep
 import com.demonwav.mcdev.platform.PlatformType
@@ -66,7 +65,7 @@ class BukkitMavenCreator(
     config: BukkitProjectConfig
 ) : BukkitProjectCreator<MavenBuildSystem>(rootDirectory, rootModule, buildSystem, config) {
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val pomText = BukkitTemplate.applyPom(project)
         return listOf(
             setupDependencyStep(),
@@ -77,30 +76,6 @@ class BukkitMavenCreator(
             BasicMavenFinalizerStep(rootModule, rootDirectory)
         )
     }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val depStep = setupDependencyStep()
-        val commonDepStep = CommonModuleDependencyStep(buildSystem)
-        val mainClassStep = setupMainClassStep()
-        val ymlStep = setupYmlStep()
-
-        val pomText = BukkitTemplate.applySubPom(project)
-        val mavenStep = BasicMavenStep(
-            project = project,
-            rootDirectory = rootDirectory,
-            buildSystem = buildSystem,
-            config = config,
-            pomText = pomText,
-            parts = listOf(
-                BasicMavenStep.setupDirs(),
-                BasicMavenStep.setupSubCore(buildSystem.parentOrError.artifactId),
-                BasicMavenStep.setupSubName(config.type),
-                BasicMavenStep.setupInfo(),
-                BasicMavenStep.setupDependencies()
-            )
-        )
-        return listOf(depStep, commonDepStep, mavenStep, mainClassStep, ymlStep)
-    }
 }
 
 class BukkitGradleCreator(
@@ -110,7 +85,7 @@ class BukkitGradleCreator(
     config: BukkitProjectConfig
 ) : BukkitProjectCreator<GradleBuildSystem>(rootDirectory, rootModule, buildSystem, config) {
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val buildText = BukkitTemplate.applyBuildGradle(project, buildSystem, config)
         val propText = BukkitTemplate.applyGradleProp(project)
         val settingsText = BukkitTemplate.applySettingsGradle(project, buildSystem.artifactId)
@@ -125,19 +100,6 @@ class BukkitGradleCreator(
             GradleWrapperStep(project, rootDirectory, buildSystem),
             GradleGitignoreStep(project, rootDirectory),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem)
-        )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val buildText = BukkitTemplate.applySubBuildGradle(project, buildSystem)
-        val files = GradleFiles(buildText, null, null)
-
-        return listOf(
-            setupDependencyStep(),
-            CreateDirectoriesStep(buildSystem, rootDirectory),
-            GradleSetupStep(project, rootDirectory, buildSystem, files),
-            setupMainClassStep(),
-            setupYmlStep()
         )
     }
 }

--- a/src/main/kotlin/platform/bukkit/creator/BukkitProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/bukkit/creator/BukkitProjectSettingsWizard.kt
@@ -20,7 +20,6 @@ import com.demonwav.mcdev.creator.ValidatedFieldType.NON_BLANK
 import com.demonwav.mcdev.creator.getVersionSelector
 import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.bukkit.data.LoadOrder
-import com.demonwav.mcdev.util.firstOfType
 import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -65,11 +64,11 @@ class BukkitProjectSettingsWizard(private val creator: MinecraftProjectCreator) 
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is BukkitProjectConfig }
+        return creator.config is BukkitProjectConfig
     }
 
     override fun updateStep() {
-        config = creator.configs.firstOfType()
+        config = creator.config as? BukkitProjectConfig
         if (config == null) {
             return
         }

--- a/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectCreator.kt
+++ b/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectCreator.kt
@@ -25,7 +25,6 @@ import com.demonwav.mcdev.creator.buildsystem.gradle.GradleSetupStep
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleWrapperStep
 import com.demonwav.mcdev.creator.buildsystem.maven.BasicMavenFinalizerStep
 import com.demonwav.mcdev.creator.buildsystem.maven.BasicMavenStep
-import com.demonwav.mcdev.creator.buildsystem.maven.CommonModuleDependencyStep
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenBuildSystem
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenGitignoreStep
 import com.demonwav.mcdev.platform.PlatformType
@@ -65,7 +64,7 @@ class BungeeCordMavenCreator(
     config: BungeeCordProjectConfig
 ) : BungeeCordProjectCreator<MavenBuildSystem>(rootDirectory, rootModule, buildSystem, config) {
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val pomText = BungeeCordTemplate.applyPom(project)
         return listOf(
             setupDependencyStep(),
@@ -76,30 +75,6 @@ class BungeeCordMavenCreator(
             BasicMavenFinalizerStep(rootModule, rootDirectory)
         )
     }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val depStep = setupDependencyStep()
-        val commonDepStep = CommonModuleDependencyStep(buildSystem)
-        val mainClassStep = setupMainClassStep()
-        val ymlStep = setupYmlStep()
-
-        val pomText = BungeeCordTemplate.applySubPom(project)
-        val mavenStep = BasicMavenStep(
-            project = project,
-            rootDirectory = rootDirectory,
-            buildSystem = buildSystem,
-            config = config,
-            pomText = pomText,
-            parts = listOf(
-                BasicMavenStep.setupDirs(),
-                BasicMavenStep.setupSubCore(buildSystem.parentOrError.artifactId),
-                BasicMavenStep.setupSubName(config.type),
-                BasicMavenStep.setupInfo(),
-                BasicMavenStep.setupDependencies()
-            )
-        )
-        return listOf(depStep, commonDepStep, mavenStep, mainClassStep, ymlStep)
-    }
 }
 
 class BungeeCordGradleCreator(
@@ -109,7 +84,7 @@ class BungeeCordGradleCreator(
     config: BungeeCordProjectConfig
 ) : BungeeCordProjectCreator<GradleBuildSystem>(rootDirectory, rootModule, buildSystem, config) {
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val buildText = BungeeCordTemplate.applyBuildGradle(project, buildSystem)
         val projectText = BungeeCordTemplate.applyGradleProp(project)
         val settingsText = BungeeCordTemplate.applySettingsGradle(project, buildSystem.artifactId)
@@ -124,19 +99,6 @@ class BungeeCordGradleCreator(
             GradleWrapperStep(project, rootDirectory, buildSystem),
             GradleGitignoreStep(project, rootDirectory),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem)
-        )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val buildText = BungeeCordTemplate.applySubBuildGradle(project, buildSystem)
-        val files = GradleFiles(buildText, null, null)
-
-        return listOf(
-            setupDependencyStep(),
-            CreateDirectoriesStep(buildSystem, rootDirectory),
-            GradleSetupStep(project, rootDirectory, buildSystem, files),
-            setupMainClassStep(),
-            setupYmlStep()
         )
     }
 }

--- a/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/bungeecord/creator/BungeeCordProjectSettingsWizard.kt
@@ -19,7 +19,6 @@ import com.demonwav.mcdev.creator.ValidatedFieldType.LIST
 import com.demonwav.mcdev.creator.ValidatedFieldType.NON_BLANK
 import com.demonwav.mcdev.creator.getVersionSelector
 import com.demonwav.mcdev.platform.PlatformType
-import com.demonwav.mcdev.util.firstOfType
 import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -67,7 +66,7 @@ class BungeeCordProjectSettingsWizard(
     }
 
     override fun updateStep() {
-        config = creator.configs.firstOfType()
+        config = creator.config as? BungeeCordProjectConfig
         if (config == null) {
             return
         }
@@ -102,7 +101,7 @@ class BungeeCordProjectSettingsWizard(
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is BungeeCordProjectConfig }
+        return creator.config is BungeeCordProjectConfig
     }
 
     override fun updateDataModel() {

--- a/src/main/kotlin/platform/fabric/creator/FabricProjectCreator.kt
+++ b/src/main/kotlin/platform/fabric/creator/FabricProjectCreator.kt
@@ -14,7 +14,6 @@ import com.demonwav.mcdev.asset.MCDevBundle
 import com.demonwav.mcdev.creator.BaseProjectCreator
 import com.demonwav.mcdev.creator.CreatorStep
 import com.demonwav.mcdev.creator.LicenseStep
-import com.demonwav.mcdev.creator.PostMultiModuleAware
 import com.demonwav.mcdev.creator.buildsystem.BuildSystem
 import com.demonwav.mcdev.creator.buildsystem.gradle.BasicGradleFinalizerStep
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleBuildSystem
@@ -65,9 +64,9 @@ class FabricProjectCreator(
     private val rootModule: Module,
     private val buildSystem: GradleBuildSystem,
     private val config: FabricProjectConfig
-) : BaseProjectCreator(rootModule, buildSystem), PostMultiModuleAware {
+) : BaseProjectCreator(rootModule, buildSystem) {
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val buildText = FabricTemplate.applyBuildGradle(project, buildSystem, config)
         val propText = FabricTemplate.applyGradleProp(project, buildSystem, config)
         val settingsText = FabricTemplate.applySettingsGradle(project, buildSystem, config)
@@ -88,34 +87,6 @@ class FabricProjectCreator(
         if (config.mixins) {
             steps += MixinConfigStep(project, buildSystem, config)
         }
-        createPostSteps(steps)
-        steps += FabricModJsonStep(project, buildSystem, config)
-        return steps
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val buildText = FabricTemplate.applyMultiModuleBuildGradle(project, buildSystem, config)
-        val propText = FabricTemplate.applyMultiModuleGradleProp(project, buildSystem, config)
-        val settingsText = FabricTemplate.applySettingsGradle(project, buildSystem, config)
-        val files = GradleFiles(buildText, propText, settingsText)
-
-        val steps = mutableListOf<CreatorStep>(
-            SimpleGradleSetupStep(project, rootDirectory, buildSystem, files)
-        )
-        if (config.genSources) {
-            steps += GenSourcesStep(project, rootDirectory)
-        }
-        config.license?.let {
-            steps += LicenseStep(project, rootDirectory, it, config.authors.joinToString(", "))
-        }
-        if (config.mixins) {
-            steps += MixinConfigStep(project, buildSystem, config)
-        }
-        return steps
-    }
-
-    override fun getPostMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val steps = mutableListOf<CreatorStep>()
         createPostSteps(steps)
         steps += FabricModJsonStep(project, buildSystem, config)
         return steps

--- a/src/main/kotlin/platform/fabric/creator/FabricProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/fabric/creator/FabricProjectSettingsWizard.kt
@@ -16,7 +16,6 @@ import com.demonwav.mcdev.creator.MinecraftProjectCreator
 import com.demonwav.mcdev.creator.ValidatedField
 import com.demonwav.mcdev.creator.ValidatedFieldType.LIST
 import com.demonwav.mcdev.creator.ValidatedFieldType.NON_BLANK
-import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.fabric.EntryPoint
 import com.demonwav.mcdev.platform.fabric.util.FabricConstants
 import com.demonwav.mcdev.platform.forge.inspections.sideonly.Side
@@ -142,16 +141,9 @@ class FabricProjectSettingsWizard(private val creator: MinecraftProjectCreator) 
         val (conf, buildSystem) = modUpdateStep<FabricProjectConfig>(creator, modNameField) ?: return
         config = conf
 
-        if (creator.configs.indexOf(conf) != 0) {
-            modNameField.isEditable = false
-        }
-
         if (!initializedEntryPointsTable) {
             val packageName = "${buildSystem.groupId.toPackageName()}.${buildSystem.artifactId.toPackageName()}"
-            var className = buildSystem.artifactId.replace('-', ' ').let { WordUtils.capitalize(it) }.replace(" ", "")
-            if (creator.configs.size > 1) {
-                className += PlatformType.FABRIC.normalName
-            }
+            val className = buildSystem.artifactId.replace('-', ' ').let { WordUtils.capitalize(it) }.replace(" ", "")
             entryPoints.add(
                 EntryPoint(
                     "main",
@@ -204,7 +196,7 @@ class FabricProjectSettingsWizard(private val creator: MinecraftProjectCreator) 
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is FabricProjectConfig }
+        return creator.config is FabricProjectConfig
     }
 
     override fun onStepLeaving() {

--- a/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
@@ -51,7 +51,7 @@ class Fg2ProjectCreator(
         }
     }
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val buildText = Fg2Template.applyBuildGradle(project, buildSystem, mcVersion)
         val propText = Fg2Template.applyGradleProp(project, config)
         val settingsText = Fg2Template.applySettingsGradle(project, buildSystem.artifactId)
@@ -71,25 +71,6 @@ class Fg2ProjectCreator(
             GradleGitignoreStep(project, rootDirectory),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem),
             ForgeRunConfigsStep(buildSystem, rootDirectory, config, CreatedModuleType.SINGLE)
-        )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val buildText = Fg2Template.applySubBuildGradle(project, buildSystem, mcVersion)
-        val propText = Fg2Template.applyGradleProp(project, config)
-        val files = GradleFiles(buildText, propText, null)
-
-        return listOf(
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                files
-            ),
-            setupMainClassStep(),
-            McmodInfoStep(project, buildSystem, config),
-            SetupDecompWorkspaceStep(project, rootDirectory),
-            ForgeRunConfigsStep(buildSystem, projectBaseDir, config, CreatedModuleType.MULTI)
         )
     }
 
@@ -130,7 +111,7 @@ open class Fg3ProjectCreator(
         return GradleFiles(buildText, propText, settingsText)
     }
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val files = createGradleFiles(hasData = true)
         val steps = mutableListOf(
             SimpleGradleSetupStep(
@@ -147,32 +128,6 @@ open class Fg3ProjectCreator(
             LicenseStep(project, rootDirectory, config.license, config.authors.joinToString(", ")),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem),
             ForgeRunConfigsStep(buildSystem, rootDirectory, config, CreatedModuleType.SINGLE)
-        )
-
-        if (config.mixins) {
-            steps += MixinConfigStep(project, buildSystem)
-        }
-
-        return steps
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val modName = transformModName(config.pluginName)
-        val buildText = Fg3Template.applySubBuildGradle(project, buildSystem, config, modName, hasData = true)
-        val files = GradleFiles(buildText, null, null)
-
-        val steps = mutableListOf(
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                files
-            ),
-            setupMainClassStep(),
-            Fg3ProjectFilesStep(project, buildSystem, config),
-            Fg3CompileJavaStep(project, rootDirectory),
-            LicenseStep(project, rootDirectory, config.license, config.authors.joinToString(", ")),
-            ForgeRunConfigsStep(buildSystem, projectBaseDir, config, CreatedModuleType.MULTI)
         )
 
         if (config.mixins) {
@@ -200,7 +155,7 @@ class Fg3Mc112ProjectCreator(
         }
     }
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val files = createGradleFiles(hasData = false)
 
         return listOf(
@@ -217,25 +172,6 @@ class Fg3Mc112ProjectCreator(
             GradleGitignoreStep(project, rootDirectory),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem),
             ForgeRunConfigsStep(buildSystem, rootDirectory, config, CreatedModuleType.SINGLE)
-        )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val modName = transformModName(config.pluginName)
-        val buildText = Fg3Template.applySubBuildGradle(project, buildSystem, config, modName, hasData = false)
-        val files = GradleFiles(buildText, null, null)
-
-        return listOf(
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                files
-            ),
-            setupMainClassStep(),
-            McmodInfoStep(project, buildSystem, config),
-            Fg3CompileJavaStep(project, rootDirectory),
-            ForgeRunConfigsStep(buildSystem, projectBaseDir, config, CreatedModuleType.MULTI)
         )
     }
 }

--- a/src/main/kotlin/platform/forge/creator/ForgeProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectSettingsWizard.kt
@@ -17,7 +17,6 @@ import com.demonwav.mcdev.creator.ValidatedField
 import com.demonwav.mcdev.creator.ValidatedFieldType.CLASS_NAME
 import com.demonwav.mcdev.creator.ValidatedFieldType.LIST
 import com.demonwav.mcdev.creator.ValidatedFieldType.NON_BLANK
-import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.forge.version.ForgeVersion
 import com.demonwav.mcdev.platform.mcp.McpVersionPair
 import com.demonwav.mcdev.platform.mcp.version.McpVersion
@@ -126,15 +125,7 @@ class ForgeProjectSettingsWizard(private val creator: MinecraftProjectCreator) :
         val (conf, buildSystem) = modUpdateStep<ForgeProjectConfig>(creator, modNameField) ?: return
         config = conf
 
-        if (creator.configs.indexOf(conf) != 0) {
-            modNameField.isEditable = false
-        }
-
         mainClassField.text = generateClassName(buildSystem, modNameField.text)
-
-        if (creator.configs.size > 1) {
-            mainClassField.text = mainClassField.text + PlatformType.FORGE.normalName
-        }
 
         title.icon = PlatformAssets.FORGE_ICON_2X
         title.text = "<html><font size=\"5\">Forge Settings</font></html>"
@@ -163,7 +154,7 @@ class ForgeProjectSettingsWizard(private val creator: MinecraftProjectCreator) :
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is ForgeProjectConfig }
+        return creator.config is ForgeProjectConfig
     }
 
     override fun onStepLeaving() {

--- a/src/main/kotlin/platform/liteloader/creator/LiteLoaderProjectCreator.kt
+++ b/src/main/kotlin/platform/liteloader/creator/LiteLoaderProjectCreator.kt
@@ -37,7 +37,7 @@ class LiteLoaderProjectCreator(
         }
     }
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val buildText = LiteLoaderTemplate.applyBuildGradle(project, buildSystem, config.mcVersion)
         val propText = LiteLoaderTemplate.applyGradleProp(project, config)
         val settingsText = LiteLoaderTemplate.applySettingsGradle(project, buildSystem.artifactId)
@@ -55,23 +55,6 @@ class LiteLoaderProjectCreator(
             SetupDecompWorkspaceStep(project, rootDirectory),
             GradleGitignoreStep(project, rootDirectory),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem)
-        )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val buildText = LiteLoaderTemplate.applySubBuildGradle(project, buildSystem, config.mcVersion)
-        val propText = LiteLoaderTemplate.applyGradleProp(project, config)
-        val files = GradleFiles(buildText, propText, null)
-
-        return listOf(
-            SimpleGradleSetupStep(
-                project,
-                rootDirectory,
-                buildSystem,
-                files
-            ),
-            setupMainClassStep(),
-            SetupDecompWorkspaceStep(project, rootDirectory)
         )
     }
 }

--- a/src/main/kotlin/platform/liteloader/creator/LiteLoaderProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/liteloader/creator/LiteLoaderProjectSettingsWizard.kt
@@ -21,7 +21,6 @@ import com.demonwav.mcdev.platform.liteloader.version.LiteLoaderVersion
 import com.demonwav.mcdev.platform.mcp.version.McpVersion
 import com.demonwav.mcdev.platform.mcp.version.McpVersionEntry
 import com.demonwav.mcdev.util.SemanticVersion
-import com.demonwav.mcdev.util.firstOfType
 import com.demonwav.mcdev.util.invokeLater
 import com.intellij.openapi.ui.MessageType
 import com.intellij.openapi.ui.popup.Balloon
@@ -167,20 +166,18 @@ class LiteLoaderProjectSettingsWizard(private val creator: MinecraftProjectCreat
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is LiteLoaderProjectConfig }
+        return creator.config is LiteLoaderProjectConfig
     }
 
     override fun updateStep() {
-        config = creator.configs.firstOfType()
-        val conf = config ?: return
+        config = creator.config as? LiteLoaderProjectConfig
+        if (config == null) {
+            return
+        }
 
         val buildSystem = creator.buildSystem ?: return
 
         modNameField.text = WordUtils.capitalizeFully(buildSystem.artifactId.replace('-', ' '))
-
-        if (creator.configs.indexOf(conf) != 0) {
-            modNameField.isEditable = false
-        }
 
         mainClassField.document.removeDocumentListener(listener)
         mainClassField.text = generateClassName(buildSystem, modNameField.text) { name -> LITEMOD + name }

--- a/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
+++ b/src/main/kotlin/platform/sponge/creator/Sponge8ProjectCreator.kt
@@ -23,7 +23,6 @@ import com.demonwav.mcdev.creator.buildsystem.gradle.GradleSetupStep
 import com.demonwav.mcdev.creator.buildsystem.gradle.GradleWrapperStep
 import com.demonwav.mcdev.creator.buildsystem.maven.BasicMavenFinalizerStep
 import com.demonwav.mcdev.creator.buildsystem.maven.BasicMavenStep
-import com.demonwav.mcdev.creator.buildsystem.maven.CommonModuleDependencyStep
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenBuildSystem
 import com.demonwav.mcdev.creator.buildsystem.maven.MavenGitignoreStep
 import com.intellij.openapi.module.Module
@@ -58,7 +57,7 @@ class Sponge8MavenCreator(
     config: SpongeProjectConfig
 ) : Sponge8ProjectCreator<MavenBuildSystem>(rootDirectory, rootModule, buildSystem, config) {
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val mainClassStep = setupMainClassStep()
         val pluginsJsonStep = CreatePluginsJsonStep(project, buildSystem, config)
 
@@ -72,30 +71,6 @@ class Sponge8MavenCreator(
             MavenGitignoreStep(project, rootDirectory),
             BasicMavenFinalizerStep(rootModule, rootDirectory),
         )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val depStep = setupDependencyStep()
-        val commonDepStep = CommonModuleDependencyStep(buildSystem)
-        val mainClassStep = setupMainClassStep()
-        val pluginsJsonStep = CreatePluginsJsonStep(project, buildSystem, config)
-
-        val pomText = SpongeTemplate.applySubPom(project)
-        val mavenStep = BasicMavenStep(
-            project = project,
-            rootDirectory = rootDirectory,
-            buildSystem = buildSystem,
-            config = config,
-            pomText = pomText,
-            parts = listOf(
-                BasicMavenStep.setupDirs(),
-                BasicMavenStep.setupSubCore(buildSystem.parentOrError.artifactId),
-                BasicMavenStep.setupSubName(config.type),
-                BasicMavenStep.setupInfo(),
-                BasicMavenStep.setupDependencies()
-            )
-        )
-        return listOf(depStep, commonDepStep, mavenStep, mainClassStep, pluginsJsonStep)
     }
 }
 
@@ -118,7 +93,7 @@ class Sponge8GradleCreator(
     config: SpongeProjectConfig
 ) : Sponge8ProjectCreator<GradleBuildSystem>(rootDirectory, rootModule, buildSystem, config) {
 
-    override fun getSingleModuleSteps(): Iterable<CreatorStep> {
+    override fun getSteps(): Iterable<CreatorStep> {
         val mainClassStep = setupMainClassStep()
 
         val buildText = Sponge8Template.applyBuildGradle(
@@ -137,23 +112,6 @@ class Sponge8GradleCreator(
             GradleWrapperStep(project, rootDirectory, buildSystem),
             GradleGitignoreStep(project, rootDirectory),
             BasicGradleFinalizerStep(rootModule, rootDirectory, buildSystem, "runServer")
-        )
-    }
-
-    override fun getMultiModuleSteps(projectBaseDir: Path): Iterable<CreatorStep> {
-        val mainClassStep = setupMainClassStep()
-
-        val buildText = Sponge8Template.applySubBuildGradle(
-            project,
-            buildSystem,
-            config
-        )
-        val files = GradleFiles(buildText, null, null)
-
-        return listOf(
-            CreateDirectoriesStep(buildSystem, rootDirectory),
-            GradleSetupStep(project, rootDirectory, buildSystem, files, true),
-            mainClassStep
         )
     }
 }

--- a/src/main/kotlin/platform/sponge/creator/SpongeProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/sponge/creator/SpongeProjectSettingsWizard.kt
@@ -21,7 +21,6 @@ import com.demonwav.mcdev.platform.sponge.SpongeVersion
 import com.demonwav.mcdev.platform.sponge.util.SpongeConstants
 import com.demonwav.mcdev.util.License
 import com.demonwav.mcdev.util.SemanticVersion
-import com.demonwav.mcdev.util.firstOfType
 import com.intellij.ui.EnumComboBoxModel
 import com.intellij.util.text.nullize
 import com.intellij.util.ui.UIUtil
@@ -77,7 +76,7 @@ class SpongeProjectSettingsWizard(private val creator: MinecraftProjectCreator) 
     }
 
     override fun updateStep() {
-        config = creator.configs.firstOfType()
+        config = creator.config as? SpongeProjectConfig
         if (config == null) {
             return
         }
@@ -109,7 +108,7 @@ class SpongeProjectSettingsWizard(private val creator: MinecraftProjectCreator) 
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is SpongeProjectConfig }
+        return creator.config is SpongeProjectConfig
     }
 
     override fun updateDataModel() {

--- a/src/main/kotlin/platform/velocity/creator/VelocityProjectSettingsWizard.kt
+++ b/src/main/kotlin/platform/velocity/creator/VelocityProjectSettingsWizard.kt
@@ -17,7 +17,6 @@ import com.demonwav.mcdev.creator.ValidatedFieldType.CLASS_NAME
 import com.demonwav.mcdev.creator.ValidatedFieldType.LIST
 import com.demonwav.mcdev.creator.ValidatedFieldType.NON_BLANK
 import com.demonwav.mcdev.creator.getVersionSelector
-import com.demonwav.mcdev.util.firstOfType
 import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -62,7 +61,7 @@ class VelocityProjectSettingsWizard(private val creator: MinecraftProjectCreator
     }
 
     override fun updateStep() {
-        config = creator.configs.firstOfType()
+        config = creator.config as? VelocityProjectConfig
         if (config == null) {
             return
         }
@@ -85,7 +84,7 @@ class VelocityProjectSettingsWizard(private val creator: MinecraftProjectCreator
     }
 
     override fun isStepVisible(): Boolean {
-        return creator.configs.any { it is VelocityProjectConfig }
+        return creator.config is VelocityProjectConfig
     }
 
     override fun updateDataModel() {

--- a/src/main/kotlin/util/mod-creator.kt
+++ b/src/main/kotlin/util/mod-creator.kt
@@ -24,6 +24,6 @@ inline fun <reified T : ProjectConfig> modUpdateStep(
 
     modNameField.text = WordUtils.capitalize(buildSystem.artifactId.replace('-', ' '))
 
-    val config = creator.configs.firstOfType<T>() ?: return null
+    val config = creator.config as? T ?: return null
     return config to buildSystem
 }


### PR DESCRIPTION
Multi-module creators were becoming a maintenance burden with little benefit. Multi-module projects are still supported, only the creators are being removed (so you have to create them manually from now on - most complex projects have significant customization in their buildscripts anyway). This will simplify adding new project creators in the future.