### PR TITLE
Fix Forge platform version detection.

### DIFF
--- a/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelFG3Handler.kt
+++ b/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelFG3Handler.kt
@@ -44,7 +44,7 @@ object McpModelFG3Handler : McpModelDataHandler {
             mcVersion = minecraftDepVersion.substring(0, index)
 
             val forgeVersionEnd = minecraftDepVersion.indexOf('_')
-            if (forgeVersionEnd != -1) {
+            if (forgeVersionEnd != -1 && forgeVersionEnd > index) {
                 forgeVersion = minecraftDepVersion.substring(index + 1, forgeVersionEnd)
             }
             break


### PR DESCRIPTION
The MinecraftDev plugin tries to detect the minecraft version from the name of the minecraft dependency.
However in doing so it assumed that the Forge Version would always be present, which is not the case if FG is run in vanilla mode.

In that vanilla mode the version string has a different format where the "_" is after the "-", causing an exception when the version substring is about the be loaded.

This fix checks for this additional condition and prevents the crash from occuring.