### PR TITLE
Support loom 0.13 and fix decompile options when using split Minecraft jars.

### DIFF
--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/fabricloom/FabricLoomModelBuilderImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/fabricloom/FabricLoomModelBuilderImpl.groovy
@@ -30,15 +30,50 @@ class FabricLoomModelBuilderImpl implements ModelBuilderService {
         }
 
         def loomExtension = project.extensions.getByName('loom')
-        def tinyMappings = loomExtension.mappingsProvider.tinyMappings.toFile().getAbsoluteFile()
-        def decompilers = loomExtension.decompilerOptions.collectEntries {
-            def task = project.tasks.getByName('genSourcesWith' + it.name.capitalize())
-            def sourcesPath = task.runtimeJar.get().getAsFile().getAbsolutePath().dropRight(4) + "-sources.jar"
-            [it.name, sourcesPath]
+
+        try {
+            return build(project, loomExtension)
+        } catch (GroovyRuntimeException ignored) {
+            // Must be using an older loom version, fallback.
+            return buildLegacy(project, loomExtension)
+        }
+    }
+
+    FabricLoomModel build(Project project, Object loomExtension) {
+        def tinyMappings = loomExtension.mappingsFile
+        def splitMinecraftJar = loomExtension.areEnvironmentSourceSetsSplit()
+
+        def decompilers = [:]
+
+        if (splitMinecraftJar) {
+            decompilers << ["common": getDecompilers(loomExtension, false)]
+            decompilers << ["client": getDecompilers(loomExtension, true)]
+        } else {
+            decompilers << ["single": getDecompilers(loomExtension, false)]
         }
 
         //noinspection GroovyAssignabilityCheck
-        return new FabricLoomModelImpl(tinyMappings, decompilers)
+        return new FabricLoomModelImpl(tinyMappings, decompilers, splitMinecraftJar)
+    }
+
+    List<FabricLoomModelImpl.DecompilerModelImpl> getDecompilers(Object loomExtension, boolean client) {
+        loomExtension.decompilerOptions.collect {
+            def task = loomExtension.getDecompileTask(it, client)
+            def sourcesPath = task.outputJar.get().getAsFile().getAbsolutePath()
+            new FabricLoomModelImpl.DecompilerModelImpl(name: it.name, taskName: task.name, sourcesPath: sourcesPath)
+        }
+    }
+
+    FabricLoomModel buildLegacy(Project project, Object loomExtension) {
+        def tinyMappings = loomExtension.mappingsProvider.tinyMappings.toFile().getAbsoluteFile()
+        def decompilers = loomExtension.decompilerOptions.collect {
+            def task = project.tasks.getByName('genSourcesWith' + it.name.capitalize())
+            def sourcesPath = task.runtimeJar.get().getAsFile().getAbsolutePath().dropRight(4) + "-sources.jar"
+            new FabricLoomModelImpl.DecompilerModelImpl(name: it.name, taskName: task.name, sourcesPath: sourcesPath)
+        }
+
+        //noinspection GroovyAssignabilityCheck
+        return new FabricLoomModelImpl(tinyMappings, ["single": decompilers], false)
     }
 
     @Override

--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/fabricloom/FabricLoomModelImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/fabricloom/FabricLoomModelImpl.groovy
@@ -10,23 +10,18 @@
 
 package com.demonwav.mcdev.platform.mcp.gradle.tooling.fabricloom
 
+import groovy.transform.Immutable
+
+@Immutable(knownImmutableClasses = [File])
 class FabricLoomModelImpl implements FabricLoomModel, Serializable {
+    File tinyMappings
+    Map<String, List<DecompilerModel>> decompilers
+    boolean splitMinecraftJar
 
-    private final File tinyMappings
-    private final Map<String, String> decompilers
-
-    FabricLoomModelImpl(File tinyMappings, Map<String, String> decompilers) {
-        this.tinyMappings = tinyMappings
-        this.decompilers = decompilers
-    }
-
-    @Override
-    File getTinyMappings() {
-        return tinyMappings
-    }
-
-    @Override
-    Map<String, String> getDecompilers() {
-        return decompilers
+    @Immutable
+    static class DecompilerModelImpl implements DecompilerModel, Serializable {
+        String name
+        String taskName
+        String sourcesPath
     }
 }

--- a/src/gradle-tooling-extension/java/com/demonwav/mcdev/platform/mcp/gradle/tooling/fabricloom/FabricLoomModel.java
+++ b/src/gradle-tooling-extension/java/com/demonwav/mcdev/platform/mcp/gradle/tooling/fabricloom/FabricLoomModel.java
@@ -11,11 +11,23 @@
 package com.demonwav.mcdev.platform.mcp.gradle.tooling.fabricloom;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 
 public interface FabricLoomModel {
 
     File getTinyMappings();
 
-    Map<String, String> getDecompilers();
+    Map<String, List<DecompilerModel>> getDecompilers();
+
+    boolean getSplitMinecraftJar();
+
+    interface DecompilerModel {
+
+        String getName();
+
+        String getTaskName();
+
+        String getSourcesPath();
+    }
 }

--- a/src/main/kotlin/platform/fabric/util/FabricConstants.kt
+++ b/src/main/kotlin/platform/fabric/util/FabricConstants.kt
@@ -18,6 +18,5 @@ object FabricConstants {
     const val CLIENT_MOD_INITIALIZER = "net.fabricmc.api.ClientModInitializer"
     const val ENVIRONMENT_ANNOTATION = "net.fabricmc.api.Environment"
     const val ENV_TYPE = "net.fabricmc.api.EnvType"
-    const val ENV_TYPE_CLIENT = "$ENV_TYPE.CLIENT"
     const val ENVIRONMENT_INTERFACE_ANNOTATION = "net.fabricmc.api.EnvironmentInterface"
 }

--- a/src/main/kotlin/platform/fabric/util/FabricConstants.kt
+++ b/src/main/kotlin/platform/fabric/util/FabricConstants.kt
@@ -18,5 +18,6 @@ object FabricConstants {
     const val CLIENT_MOD_INITIALIZER = "net.fabricmc.api.ClientModInitializer"
     const val ENVIRONMENT_ANNOTATION = "net.fabricmc.api.Environment"
     const val ENV_TYPE = "net.fabricmc.api.EnvType"
+    const val ENV_TYPE_CLIENT = "$ENV_TYPE.CLIENT"
     const val ENVIRONMENT_INTERFACE_ANNOTATION = "net.fabricmc.api.EnvironmentInterface"
 }

--- a/src/main/kotlin/platform/mcp/fabricloom/FabricLoomData.kt
+++ b/src/main/kotlin/platform/mcp/fabricloom/FabricLoomData.kt
@@ -19,7 +19,8 @@ import java.io.File
 data class FabricLoomData(
     val module: ModuleData,
     val tinyMappings: File?,
-    val decompileTasks: Set<Decompiler>
+    val decompileTasks: Map<String, Set<Decompiler>>,
+    val splitMinecraftJar: Boolean
 ) : AbstractExternalEntityData(module.owner) {
 
     data class Decompiler(val name: String, val taskName: String, val sourcesPath: String)

--- a/src/main/kotlin/platform/mcp/fabricloom/FabricLoomProjectResolverExtension.kt
+++ b/src/main/kotlin/platform/mcp/fabricloom/FabricLoomProjectResolverExtension.kt
@@ -11,7 +11,6 @@
 package com.demonwav.mcdev.platform.mcp.fabricloom
 
 import com.demonwav.mcdev.platform.mcp.gradle.tooling.fabricloom.FabricLoomModel
-import com.demonwav.mcdev.util.capitalize
 import com.intellij.openapi.externalSystem.model.DataNode
 import com.intellij.openapi.externalSystem.model.project.ModuleData
 import org.gradle.tooling.model.idea.IdeaModule
@@ -27,14 +26,13 @@ class FabricLoomProjectResolverExtension : AbstractProjectResolverExtension() {
     override fun populateModuleExtraModels(gradleModule: IdeaModule, ideModule: DataNode<ModuleData>) {
         val loomData = resolverCtx.getExtraProject(gradleModule, FabricLoomModel::class.java)
         if (loomData != null) {
-            val gradleProjectPath = gradleModule.gradleProject.projectIdentifier.projectPath
-            val suffix = if (gradleProjectPath.endsWith(':')) "" else ":"
-            val decompileTasksNames = loomData.decompilers.mapTo(mutableSetOf()) { (rawName, sourcesPath) ->
-                val name = rawName.capitalize()
-                val taskName = gradleProjectPath + suffix + "genSourcesWith" + name
-                FabricLoomData.Decompiler(name, taskName, sourcesPath)
+            val decompilers = loomData.decompilers.mapValues { (_, decompilers) ->
+                decompilers.mapTo(mutableSetOf()) { decompiler ->
+                    FabricLoomData.Decompiler(decompiler.name, decompiler.taskName, decompiler.sourcesPath)
+                }
             }
-            val data = FabricLoomData(ideModule.data, loomData.tinyMappings, decompileTasksNames)
+
+            val data = FabricLoomData(ideModule.data, loomData.tinyMappings, decompilers, loomData.splitMinecraftJar)
             ideModule.createChild(FabricLoomData.KEY, data)
         }
 


### PR DESCRIPTION
Previously MCDev used internal APIs to get a number of values from loom. This PR moves those to use 2 new stable APIs I propose to add to loom. Backwards compatbility has been kept to ensure this still works with the current stable loom version.

Newer versions of loom support splitting the minecraft jar two common and client jars, this PR also ensures that the correct decompile task is used.

Loom PR adding new APIs: https://github.com/FabricMC/fabric-loom/pull/697

This is my first time working on an Idea plugin, and I have little Kotlin experience so please let me know if there is anything I can improve 👍 