### PR TITLE
Un-hardcode mixin annotations list

### DIFF
--- a/src/main/kotlin/platform/mixin/MixinCustomJavaDocTagProvider.kt
+++ b/src/main/kotlin/platform/mixin/MixinCustomJavaDocTagProvider.kt
@@ -10,7 +10,7 @@
 
 package com.demonwav.mcdev.platform.mixin
 
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiReference
@@ -27,10 +27,18 @@ class MixinCustomJavaDocTagProvider : CustomJavadocTagProvider {
         override fun isInline() = false
 
         override fun isValidInContext(element: PsiElement?): Boolean {
-            val modifierList = (element as? PsiMethod)?.modifierList ?: return false
-            return MixinConstants.Annotations.ENTRY_POINTS.any {
-                modifierList.findAnnotation(it) != null
+            if (element !is PsiMethod) {
+                return false
             }
+            val project = element.project
+            for (annotation in element.annotations) {
+                val qName = annotation.qualifiedName ?: continue
+                val handler = MixinAnnotationHandler.forMixinAnnotation(qName, project)
+                if (handler != null && handler.isEntryPoint) {
+                    return true
+                }
+            }
+            return false
         }
 
         override fun checkTagValue(value: PsiDocTagValue?): String? = null

--- a/src/main/kotlin/platform/mixin/handlers/AccessorHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/AccessorHandler.kt
@@ -96,6 +96,8 @@ class AccessorHandler : MixinMemberAnnotationHandler {
         ).createSmartPointer()
     }
 
+    override val isEntryPoint = false
+
     data class AccessorInfo(val name: String, val type: AccessorType)
 
     enum class AccessorType(val allowGetters: Boolean, val allowSetters: Boolean) {

--- a/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
@@ -146,6 +146,8 @@ abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
 
     open val allowCoerce = false
 
+    override val isEntryPoint = true
+
     data class InsnResult(val method: ClassAndMethodNode, val result: CollectVisitor.Result<*>)
 
     companion object {
@@ -180,4 +182,14 @@ abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
             }
         }
     }
+}
+
+object DefaultInjectorAnnotationHandler : InjectorAnnotationHandler() {
+    override fun expectedMethodSignature(
+        annotation: PsiAnnotation,
+        targetClass: ClassNode,
+        targetMethod: MethodNode
+    ) = null
+
+    override val isSoft = true
 }

--- a/src/main/kotlin/platform/mixin/handlers/InvokerHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InvokerHandler.kt
@@ -92,4 +92,6 @@ class InvokerHandler : MixinMemberAnnotationHandler {
             canDecompile = false
         ).createSmartPointer()
     }
+
+    override val isEntryPoint = false
 }

--- a/src/main/kotlin/platform/mixin/handlers/MixinAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/MixinAnnotationHandler.kt
@@ -11,13 +11,24 @@
 package com.demonwav.mcdev.platform.mixin.handlers
 
 import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.InsnResolutionInfo
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
 import com.demonwav.mcdev.platform.mixin.util.MixinTargetMember
 import com.demonwav.mcdev.platform.mixin.util.mixinTargets
+import com.demonwav.mcdev.util.findAnnotation
 import com.demonwav.mcdev.util.findContainingClass
+import com.demonwav.mcdev.util.resolveClass
+import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.RequiredElement
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.KeyedExtensionCollector
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.serviceContainer.BaseKeyedLazyInstance
 import com.intellij.util.KeyedLazyInstance
 import com.intellij.util.xmlb.annotations.Attribute
@@ -49,12 +60,56 @@ interface MixinAnnotationHandler {
 
     fun createUnresolvedMessage(annotation: PsiAnnotation): String?
 
-    companion object {
-        private val COLLECTOR =
-            KeyedExtensionCollector<MixinAnnotationHandler, String>("com.demonwav.minecraft-dev.mixinAnnotationHandler")
+    /**
+     * Returns true if we don't actually know the implementation of the annotation, and we're just making
+     * a guess. Prevents unresolved errors but still attempts navigation
+     */
+    val isSoft: Boolean get() = false
 
-        fun forMixinAnnotation(qualifiedName: String): MixinAnnotationHandler? {
-            return COLLECTOR.findSingle(qualifiedName)
+    /**
+     * Returns whether elements annotated with this annotation should be considered "entry points",
+     * i.e. not reported as unused
+     */
+    val isEntryPoint: Boolean
+
+    companion object {
+        private val EP_NAME = ExtensionPointName<KeyedLazyInstance<MixinAnnotationHandler>>(
+            "com.demonwav.minecraft-dev.mixinAnnotationHandler"
+        )
+        private val COLLECTOR = KeyedExtensionCollector<MixinAnnotationHandler, String>(EP_NAME)
+
+        fun getBuiltinHandlers(): Sequence<Pair<String, MixinAnnotationHandler>> =
+            EP_NAME.extensions.asSequence().map { it.key to it.instance }
+
+        fun forMixinAnnotation(qualifiedName: String, project: Project? = null): MixinAnnotationHandler? {
+            val extension = COLLECTOR.findSingle(qualifiedName)
+            if (extension != null) {
+                return extension
+            }
+
+            if (project != null) {
+                val extraMixinAnnotations = CachedValuesManager.getManager(project).getCachedValue(project) {
+                    val result = JavaPsiFacade.getInstance(project)
+                        .findClass(MixinConstants.Annotations.ANNOTATION_TYPE, GlobalSearchScope.allScope(project))
+                        ?.let { annotationType ->
+                            AnnotatedElementsSearch.searchPsiClasses(
+                                annotationType,
+                                GlobalSearchScope.allScope(project)
+                            ).mapNotNull { injectionInfoClass ->
+                                injectionInfoClass.findAnnotation(MixinConstants.Annotations.ANNOTATION_TYPE)
+                                    ?.findAttributeValue("value")
+                                    ?.resolveClass()
+                                    ?.qualifiedName
+                            }.toSet()
+                        } ?: emptySet()
+                    CachedValueProvider.Result(result, PsiModificationTracker.MODIFICATION_COUNT)
+                }
+                if (extraMixinAnnotations != null && qualifiedName in extraMixinAnnotations) {
+                    return DefaultInjectorAnnotationHandler
+                }
+            }
+
+            return null
         }
     }
 }

--- a/src/main/kotlin/platform/mixin/handlers/OverwriteHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/OverwriteHandler.kt
@@ -32,6 +32,8 @@ class OverwriteHandler : MixinMemberAnnotationHandler {
         return "Unresolved method ${method.name} in target class"
     }
 
+    override val isEntryPoint = true
+
     companion object {
         fun getInstance(): OverwriteHandler? {
             return MixinAnnotationHandler.forMixinAnnotation(OVERWRITE) as? OverwriteHandler

--- a/src/main/kotlin/platform/mixin/handlers/ShadowHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/ShadowHandler.kt
@@ -118,6 +118,8 @@ class ShadowHandler : MixinMemberAnnotationHandler {
         return (member.name ?: return null).removePrefix(prefix)
     }
 
+    override val isEntryPoint = false
+
     companion object {
         fun getInstance(): ShadowHandler? {
             return MixinAnnotationHandler.forMixinAnnotation(SHADOW) as? ShadowHandler

--- a/src/main/kotlin/platform/mixin/insight/MixinEntryPoint.kt
+++ b/src/main/kotlin/platform/mixin/insight/MixinEntryPoint.kt
@@ -34,7 +34,10 @@ class MixinEntryPoint : EntryPointWithVisibilityLevel() {
     // TODO: support more handlers than the builtin
     // need to find a way to access the project for that
     override fun getIgnoreAnnotations() =
-        MixinAnnotationHandler.getBuiltinHandlers().map { (name, _) -> name }.toTypedArray()
+        MixinAnnotationHandler.getBuiltinHandlers()
+            .filter { (_, handler) -> handler.isEntryPoint }
+            .map { (name, _) -> name }
+            .toTypedArray()
 
     override fun isEntryPoint(element: PsiElement): Boolean {
         if (element !is PsiMethod) {

--- a/src/main/kotlin/platform/mixin/insight/MixinEntryPoint.kt
+++ b/src/main/kotlin/platform/mixin/insight/MixinEntryPoint.kt
@@ -10,7 +10,9 @@
 
 package com.demonwav.mcdev.platform.mixin.insight
 
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.handlers.InjectorAnnotationHandler
+import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
+import com.demonwav.mcdev.util.toTypedArray
 import com.intellij.codeInspection.reference.RefElement
 import com.intellij.codeInspection.visibility.EntryPointWithVisibilityLevel
 import com.intellij.psi.PsiElement
@@ -29,25 +31,41 @@ class MixinEntryPoint : EntryPointWithVisibilityLevel() {
     override fun getDisplayName() = "Mixin injectors"
     override fun getTitle() = "Suggest private visibility level for Mixin injectors"
 
-    override fun getIgnoreAnnotations() = MixinConstants.Annotations.ENTRY_POINTS
+    // TODO: support more handlers than the builtin
+    // need to find a way to access the project for that
+    override fun getIgnoreAnnotations() =
+        MixinAnnotationHandler.getBuiltinHandlers().map { (name, _) -> name }.toTypedArray()
 
     override fun isEntryPoint(element: PsiElement): Boolean {
-        val modifierList = (element as? PsiMethod)?.modifierList ?: return false
-        return MixinConstants.Annotations.ENTRY_POINTS.any {
-            modifierList.findAnnotation(it) != null
+        if (element !is PsiMethod) {
+            return false
         }
+        val project = element.project
+        for (annotation in element.annotations) {
+            val qName = annotation.qualifiedName ?: continue
+            val handler = MixinAnnotationHandler.forMixinAnnotation(qName, project)
+            if (handler != null && handler.isEntryPoint) {
+                return true
+            }
+        }
+        return false
     }
 
     override fun isEntryPoint(refElement: RefElement, psiElement: PsiElement) = isEntryPoint(psiElement)
 
     override fun getMinVisibilityLevel(member: PsiMember): Int {
-        if (member !is PsiMethod) return -1
-        val modifierList = member.modifierList
-        return if (MixinConstants.Annotations.METHOD_INJECTORS.any { modifierList.findAnnotation(it) != null }) {
-            PsiUtil.ACCESS_LEVEL_PRIVATE
-        } else {
-            -1
+        if (member !is PsiMethod) {
+            return -1
         }
+        val project = member.project
+        for (annotation in member.annotations) {
+            val qName = annotation.qualifiedName ?: continue
+            val handler = MixinAnnotationHandler.forMixinAnnotation(qName, project)
+            if (handler is InjectorAnnotationHandler) {
+                return PsiUtil.ACCESS_LEVEL_PRIVATE
+            }
+        }
+        return -1
     }
 
     override fun isSelected() = MIXIN_ENTRY_POINT

--- a/src/main/kotlin/platform/mixin/insight/MixinTargetLineMarkerProvider.kt
+++ b/src/main/kotlin/platform/mixin/insight/MixinTargetLineMarkerProvider.kt
@@ -55,7 +55,7 @@ class MixinTargetLineMarkerProvider : LineMarkerProviderDescriptor() {
 
         val (handler, annotation) = element.annotations.mapFirstNotNull { annotation ->
             annotation.qualifiedName?.let { qName ->
-                MixinAnnotationHandler.forMixinAnnotation(qName)?.let { it to annotation }
+                MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project)?.let { it to annotation }
             }
         } ?: return null
         if (handler.isUnresolved(annotation) != null) {

--- a/src/main/kotlin/platform/mixin/inspection/MixinAnnotationAttributeInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/MixinAnnotationAttributeInspection.kt
@@ -19,11 +19,11 @@ import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiNameValuePair
 
 abstract class MixinAnnotationAttributeInspection(
-    private val annotation: List<String>,
+    private val annotation: String?,
     private val attribute: String?
 ) : MixinInspection() {
 
-    constructor(annotation: String, attribute: String?) : this(listOf(annotation), attribute)
+    constructor(attribute: String?) : this(null, attribute)
 
     protected abstract fun visitAnnotationAttribute(
         annotation: PsiAnnotation,
@@ -44,7 +44,8 @@ abstract class MixinAnnotationAttributeInspection(
             }
 
             val psiAnnotation = pair.annotationFromNameValuePair ?: return
-            if (psiAnnotation.qualifiedName !in annotation) {
+
+            if (annotation != null && !psiAnnotation.hasQualifiedName(annotation)) {
                 return
             }
 

--- a/src/main/kotlin/platform/mixin/inspection/MixinAnnotationTargetInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/MixinAnnotationTargetInspection.kt
@@ -34,7 +34,7 @@ class MixinAnnotationTargetInspection : MixinInspection() {
                     var parentAnnotation = annotation.parentOfType<PsiAnnotation>()
                     while (parentAnnotation != null) {
                         val parentQName = parentAnnotation.qualifiedName ?: return
-                        if (MixinAnnotationHandler.forMixinAnnotation(parentQName) != null) {
+                        if (MixinAnnotationHandler.forMixinAnnotation(parentQName, parentAnnotation.project) != null) {
                             break
                         }
                         parentAnnotation = parentAnnotation.parentOfType()
@@ -43,7 +43,8 @@ class MixinAnnotationTargetInspection : MixinInspection() {
                         return
                     }
                     val parentQName = parentAnnotation.qualifiedName ?: return
-                    val handler = MixinAnnotationHandler.forMixinAnnotation(parentQName) ?: return
+                    val handler = MixinAnnotationHandler.forMixinAnnotation(parentQName, parentAnnotation.project)
+                        ?: return
                     val targets = handler.resolveTarget(parentAnnotation).ifEmpty { return }
                     val failure = targets.asSequence()
                         .mapNotNull {
@@ -65,7 +66,7 @@ class MixinAnnotationTargetInspection : MixinInspection() {
                         addProblem(annotation, "Could not resolve @At target", failure)
                     }
                 } else {
-                    val handler = MixinAnnotationHandler.forMixinAnnotation(qName) ?: return
+                    val handler = MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project) ?: return
                     val failure = handler.isUnresolved(annotation)
                     if (failure != null) {
                         val message = handler.createUnresolvedMessage(annotation) ?: return

--- a/src/main/kotlin/platform/mixin/inspection/MixinAnnotationsInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/MixinAnnotationsInspection.kt
@@ -10,7 +10,7 @@
 
 package com.demonwav.mcdev.platform.mixin.inspection
 
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MIXIN_ANNOTATIONS
+import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
 import com.demonwav.mcdev.platform.mixin.util.isMixin
 import com.demonwav.mcdev.util.findContainingClass
 import com.intellij.codeInspection.ProblemsHolder
@@ -31,7 +31,7 @@ class MixinAnnotationsInspection : MixinInspection() {
 
         override fun visitAnnotation(annotation: PsiAnnotation) {
             val qualifiedName = annotation.qualifiedName ?: return
-            if (qualifiedName !in MIXIN_ANNOTATIONS) {
+            if (MixinAnnotationHandler.forMixinAnnotation(qualifiedName, annotation.project) == null) {
                 return
             }
 

--- a/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
@@ -63,7 +63,8 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
 
             for (annotation in modifiers.annotations) {
                 val qName = annotation.qualifiedName ?: continue
-                val handler = MixinAnnotationHandler.forMixinAnnotation(qName) as? InjectorAnnotationHandler ?: continue
+                val handler = MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project)
+                    as? InjectorAnnotationHandler ?: continue
                 val methodAttribute = annotation.findDeclaredAttributeValue("method") ?: continue
                 val targetMethods = MethodReference.resolveAllIfNotAmbiguous(methodAttribute) ?: continue
 

--- a/src/main/kotlin/platform/mixin/inspection/reference/AmbiguousReferenceInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/reference/AmbiguousReferenceInspection.kt
@@ -10,9 +10,10 @@
 
 package com.demonwav.mcdev.platform.mixin.inspection.reference
 
+import com.demonwav.mcdev.platform.mixin.handlers.InjectorAnnotationHandler
+import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
 import com.demonwav.mcdev.platform.mixin.inspection.MixinAnnotationAttributeInspection
 import com.demonwav.mcdev.platform.mixin.reference.MethodReference
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.METHOD_INJECTORS
 import com.demonwav.mcdev.util.constantStringValue
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
@@ -26,7 +27,7 @@ import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiBinaryExpression
 import com.intellij.psi.PsiLiteral
 
-class AmbiguousReferenceInspection : MixinAnnotationAttributeInspection(METHOD_INJECTORS, "method") {
+class AmbiguousReferenceInspection : MixinAnnotationAttributeInspection("method") {
 
     override fun getStaticDescription() = "Reports ambiguous references in Mixin annotations"
 
@@ -35,6 +36,12 @@ class AmbiguousReferenceInspection : MixinAnnotationAttributeInspection(METHOD_I
         value: PsiAnnotationMemberValue,
         holder: ProblemsHolder
     ) {
+        val qName = annotation.qualifiedName ?: return
+        val handler = MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project)
+        if (handler !is InjectorAnnotationHandler || handler.isSoft) {
+            return
+        }
+
         when (value) {
             is PsiLiteral -> checkMember(value, holder)
             is PsiArrayInitializerMemberValue -> value.initializers.forEach { checkMember(it, holder) }

--- a/src/main/kotlin/platform/mixin/inspection/reference/InvalidMemberReferenceInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/reference/InvalidMemberReferenceInspection.kt
@@ -50,7 +50,7 @@ class InvalidMemberReferenceInspection : MixinInspection() {
 
             // Check if valid annotation
             val qualifiedName = pair.annotationFromNameValuePair?.qualifiedName ?: return
-            if (!resolver.isValidAnnotation(qualifiedName)) {
+            if (!resolver.isValidAnnotation(qualifiedName, pair.project)) {
                 return
             }
 

--- a/src/main/kotlin/platform/mixin/inspection/reference/UnnecessaryQualifiedMemberReferenceInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/reference/UnnecessaryQualifiedMemberReferenceInspection.kt
@@ -10,10 +10,11 @@
 
 package com.demonwav.mcdev.platform.mixin.inspection.reference
 
+import com.demonwav.mcdev.platform.mixin.handlers.InjectorAnnotationHandler
+import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
 import com.demonwav.mcdev.platform.mixin.inspection.MixinAnnotationAttributeInspection
 import com.demonwav.mcdev.platform.mixin.reference.parseMixinSelector
 import com.demonwav.mcdev.platform.mixin.reference.toMixinString
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.METHOD_INJECTORS
 import com.demonwav.mcdev.util.MemberReference
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
@@ -25,7 +26,7 @@ import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiLiteral
 
-class UnnecessaryQualifiedMemberReferenceInspection : MixinAnnotationAttributeInspection(METHOD_INJECTORS, "method") {
+class UnnecessaryQualifiedMemberReferenceInspection : MixinAnnotationAttributeInspection("method") {
 
     override fun getStaticDescription() = "Reports unnecessary qualified member references in @Inject annotations"
 
@@ -34,6 +35,11 @@ class UnnecessaryQualifiedMemberReferenceInspection : MixinAnnotationAttributeIn
         value: PsiAnnotationMemberValue,
         holder: ProblemsHolder
     ) {
+        val qName = annotation.qualifiedName ?: return
+        if (MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project) !is InjectorAnnotationHandler) {
+            return
+        }
+
         when (value) {
             is PsiLiteral -> checkMemberReference(value, holder)
             is PsiArrayInitializerMemberValue -> value.initializers.forEach { checkMemberReference(it, holder) }

--- a/src/main/kotlin/platform/mixin/inspection/reference/UnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/reference/UnresolvedReferenceInspection.kt
@@ -46,7 +46,7 @@ class UnresolvedReferenceInspection : MixinInspection() {
 
             // Check if valid annotation
             val qualifiedName = pair.annotationFromNameValuePair?.qualifiedName ?: return
-            val resolver = resolvers.firstOrNull { it.isValidAnnotation(qualifiedName) } ?: return
+            val resolver = resolvers.firstOrNull { it.isValidAnnotation(qualifiedName, pair.project) } ?: return
 
             val value = pair.value ?: return
             if (value is PsiArrayInitializerMemberValue) {

--- a/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
@@ -10,6 +10,7 @@
 
 package com.demonwav.mcdev.platform.mixin.reference
 
+import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
 import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
 import com.demonwav.mcdev.platform.mixin.util.ClassAndMethodNode
 import com.demonwav.mcdev.platform.mixin.util.bytecode
@@ -29,11 +30,13 @@ import com.demonwav.mcdev.util.toResolveResults
 import com.demonwav.mcdev.util.toTypedArray
 import com.intellij.codeInsight.completion.JavaLookupElementBuilder
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLiteral
 import com.intellij.psi.PsiSubstitutor
 import com.intellij.psi.ResolveResult
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.ArrayUtil
 import org.objectweb.asm.tree.ClassNode
 
@@ -59,6 +62,14 @@ abstract class AbstractMethodReference : PolyReferenceResolver(), MixinReference
     }
 
     override fun isUnresolved(context: PsiElement): Boolean {
+        // check if the annotation handler is soft
+        val annotationQName = context.parentOfType<PsiAnnotation>()?.qualifiedName
+        if (annotationQName != null &&
+            MixinAnnotationHandler.forMixinAnnotation(annotationQName, context.project)?.isSoft == true
+        ) {
+            return false
+        }
+
         val stringValue = context.constantStringValue ?: return false
         val targetMethodInfo = parseSelector(stringValue, context) ?: return false
         val targets = getTargets(context) ?: return false

--- a/src/main/kotlin/platform/mixin/reference/DescReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/DescReference.kt
@@ -18,6 +18,7 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.PsiJavaPatterns
@@ -42,7 +43,7 @@ object DescReference : AbstractMethodReference() {
 
     override val description = "method '%s'"
 
-    override fun isValidAnnotation(name: String) = name == DESC
+    override fun isValidAnnotation(name: String, project: Project) = name == DESC
 
     override fun parseSelector(context: PsiElement): DescSelector? {
         val annotation = context.parentOfType<PsiAnnotation>() ?: return null // @Desc

--- a/src/main/kotlin/platform/mixin/reference/InjectionPointReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/InjectionPointReference.kt
@@ -44,7 +44,7 @@ object InjectionPointReference : ReferenceResolver(), MixinReference {
     override val description: String
         get() = "injection point type '%s'"
 
-    override fun isValidAnnotation(name: String) = name == AT
+    override fun isValidAnnotation(name: String, project: Project) = name == AT
 
     override fun resolveReference(context: PsiElement): PsiElement? {
         // Remove slice selectors from the injection point type

--- a/src/main/kotlin/platform/mixin/reference/MixinReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/MixinReference.kt
@@ -10,6 +10,7 @@
 
 package com.demonwav.mcdev.platform.mixin.reference
 
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 
 interface MixinReference {
@@ -18,5 +19,5 @@ interface MixinReference {
 
     fun isUnresolved(context: PsiElement): Boolean
 
-    fun isValidAnnotation(name: String): Boolean
+    fun isValidAnnotation(name: String, project: Project): Boolean
 }

--- a/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
@@ -21,6 +21,7 @@ import com.demonwav.mcdev.util.ifEmpty
 import com.demonwav.mcdev.util.insideAnnotationAttribute
 import com.demonwav.mcdev.util.reference.PolyReferenceResolver
 import com.demonwav.mcdev.util.reference.completeToLiteral
+import com.intellij.openapi.project.Project
 import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.PsiJavaPatterns
 import com.intellij.patterns.StandardPatterns
@@ -46,7 +47,7 @@ object TargetReference : PolyReferenceResolver(), MixinReference {
     override val description: String
         get() = "target reference '%s'"
 
-    override fun isValidAnnotation(name: String) = name == AT
+    override fun isValidAnnotation(name: String, project: Project) = name == AT
 
     fun resolveTarget(context: PsiElement): PsiMember? {
         val selector = parseMixinSelector(context) ?: return null
@@ -57,19 +58,22 @@ object TargetReference : PolyReferenceResolver(), MixinReference {
      * Null is returned when no parent annotation handler could be found, in which case we shouldn't mark this
      * reference as unresolved.
      */
-    private fun getTargets(at: PsiAnnotation): List<ClassAndMethodNode>? {
+    private fun getTargets(at: PsiAnnotation, forUnresolved: Boolean): List<ClassAndMethodNode>? {
         val (handler, annotation) = generateSequence(at.parent) { it.parent }
             .filterIsInstance<PsiAnnotation>()
             .mapNotNull { annotation ->
                 val qName = annotation.qualifiedName ?: return@mapNotNull null
-                MixinAnnotationHandler.forMixinAnnotation(qName)?.let { it to annotation }
+                MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project)?.let { it to annotation }
             }.firstOrNull() ?: return null
+        if (forUnresolved && handler.isSoft) {
+            return null
+        }
         return handler.resolveTarget(annotation).mapNotNull { (it as? MethodTargetMember)?.classAndMethod }
     }
 
     override fun isUnresolved(context: PsiElement): Boolean {
         val at = context.parentOfType<PsiAnnotation>() ?: return true
-        val targets = getTargets(at)?.ifEmpty { return true } ?: return false
+        val targets = getTargets(at, true)?.ifEmpty { return true } ?: return false
         return targets.all {
             val failure = AtResolver(at, it.clazz, it.method).isUnresolved()
             // leave it if there is a filter to blame, the target reference was at least resolved
@@ -79,7 +83,7 @@ object TargetReference : PolyReferenceResolver(), MixinReference {
 
     fun resolveNavigationTargets(context: PsiElement): Array<PsiElement>? {
         val at = context.parentOfType<PsiAnnotation>() ?: return null
-        val targets = getTargets(at) ?: return null
+        val targets = getTargets(at, false) ?: return null
         return targets.flatMap { AtResolver(at, it.clazz, it.method).resolveNavigationTargets() }.toTypedArray()
     }
 
@@ -90,7 +94,7 @@ object TargetReference : PolyReferenceResolver(), MixinReference {
 
     override fun collectVariants(context: PsiElement): Array<Any> {
         val at = context.parentOfType<PsiAnnotation>() ?: return ArrayUtilRt.EMPTY_OBJECT_ARRAY
-        val targets = getTargets(at) ?: return ArrayUtilRt.EMPTY_OBJECT_ARRAY
+        val targets = getTargets(at, false) ?: return ArrayUtilRt.EMPTY_OBJECT_ARRAY
         return targets.flatMap { target ->
             AtResolver(at, target.clazz, target.method).collectTargetVariants { builder ->
                 builder.completeToLiteral(context)

--- a/src/main/kotlin/platform/mixin/util/MixinConstants.kt
+++ b/src/main/kotlin/platform/mixin/util/MixinConstants.kt
@@ -37,6 +37,7 @@ object MixinConstants {
 
     object Annotations {
         const val ACCESSOR = "org.spongepowered.asm.mixin.gen.Accessor"
+        const val ANNOTATION_TYPE = "org.spongepowered.asm.mixin.injection.struct.InjectionInfo.AnnotationType"
         const val AT = "org.spongepowered.asm.mixin.injection.At"
         const val AT_CODE = "org.spongepowered.asm.mixin.injection.InjectionPoint.AtCode"
         const val COERCE = "org.spongepowered.asm.mixin.injection.Coerce"
@@ -63,34 +64,5 @@ object MixinConstants {
         const val MODIFY_VARIABLE = "org.spongepowered.asm.mixin.injection.ModifyVariable"
         const val REDIRECT = "org.spongepowered.asm.mixin.injection.Redirect"
         const val SURROGATE = "org.spongepowered.asm.mixin.injection.Surrogate"
-
-        val METHOD_INJECTORS = listOf(INJECT, MODIFY_ARG, MODIFY_ARGS, MODIFY_CONSTANT, MODIFY_VARIABLE, REDIRECT)
-        val ENTRY_POINTS =
-            arrayOf(INJECT, MODIFY_ARG, MODIFY_ARGS, MODIFY_CONSTANT, MODIFY_VARIABLE, REDIRECT, SURROGATE, OVERWRITE)
-        val MIXIN_ANNOTATIONS = setOf(
-            ACCESSOR,
-            AT,
-            DEBUG,
-            DYNAMIC,
-            FINAL,
-            IMPLEMENTS,
-            INTERFACE,
-            INTRINSIC,
-            MIXIN,
-            MUTABLE,
-            OVERWRITE,
-            SHADOW,
-            SLICE,
-            SOFT_OVERRIDE,
-            UNIQUE,
-            INJECT,
-            INVOKER,
-            MODIFY_ARG,
-            MODIFY_ARGS,
-            MODIFY_CONSTANT,
-            MODIFY_VARIABLE,
-            REDIRECT,
-            SURROGATE
-        )
     }
 }


### PR DESCRIPTION
This PR removes some hardcoded lists of mixin annotations, and adds some code to detect if an annotation is an injector, and assigns a default handler to it if no others are registered. This should significantly improve the experience when using custom injectors not supported by mcdev or another plugin.