### PR TITLE
Autocomplete method references in array format

### DIFF
--- a/src/main/kotlin/platform/mixin/reference/MethodReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/MethodReference.kt
@@ -26,16 +26,19 @@ import com.intellij.util.ProcessingContext
 
 object MethodReference : AbstractMethodReference() {
     val ELEMENT_PATTERN: ElementPattern<PsiLiteral> =
-        PsiJavaPatterns.psiLiteral(StandardPatterns.string()).insideAnnotationAttribute(
-            PsiJavaPatterns.psiAnnotation().with(
-                object : PatternCondition<PsiAnnotation>("injector") {
-                    override fun accepts(t: PsiAnnotation, context: ProcessingContext?): Boolean {
-                        val qName = t.qualifiedName ?: return false
-                        return MixinAnnotationHandler.forMixinAnnotation(qName, t.project) is InjectorAnnotationHandler
+        PsiJavaPatterns.psiLiteral(StandardPatterns.string()).withAncestor(
+            1,
+            PsiJavaPatterns.psiElement().insideAnnotationAttribute(
+                PsiJavaPatterns.psiAnnotation().with(
+                    object : PatternCondition<PsiAnnotation>("injector") {
+                        override fun accepts(t: PsiAnnotation, context: ProcessingContext?): Boolean {
+                            val qName = t.qualifiedName ?: return false
+                            return isValidAnnotation(qName, t.project)
+                        }
                     }
-                }
-            ),
-            "method"
+                ),
+                "method"
+            )
         )
 
     override val description = "method '%s' in target class"


### PR DESCRIPTION
Adds autocomplete to method references in array initializers.

Before | After
-------|--------
![](https://user-images.githubusercontent.com/56961087/201553468-044748eb-ea0c-4691-94ef-ba843235dec4.png) | ![](https://user-images.githubusercontent.com/56961087/201553410-658ec582-7230-432c-b250-762fe7666b58.png)
