### PR TITLE
Update FG5 Wrapper Version to 7.5.1 (to fit with MDK)

### DIFF
--- a/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
+++ b/src/main/kotlin/platform/forge/creator/ForgeProjectCreator.kt
@@ -143,7 +143,7 @@ open class Fg3ProjectCreator(
     }
 
     companion object {
-        val FG5_WRAPPER_VERSION = SemanticVersion.release(7, 4, 2)
+        val FG5_WRAPPER_VERSION = SemanticVersion.release(7, 5, 1)
     }
 }
 


### PR DESCRIPTION
This PR update FG5 Gradle Wrapper Version to 7.5.1 to fit with recent MDK (normally FG5 works with this last version, if for some version of Minecraft, it breaks something, it is possible to adapt).