### PR TITLE
Use `displayURL` field when Website field is filled

### DIFF
--- a/src/main/kotlin/platform/forge/creator/Fg3Template.kt
+++ b/src/main/kotlin/platform/forge/creator/Fg3Template.kt
@@ -226,6 +226,11 @@ object Fg3Template : BaseTemplate() {
                 props["UPDATE_URL"] = url
             }
         }
+        config.website?.let { url ->
+            if (url.isNotBlank()) {
+                props["WEBSITE"] = url
+            }
+        }
         if (config.hasAuthors()) {
             props["AUTHOR_LIST"] = config.authors.joinToString(", ")
         }

--- a/src/main/resources/fileTemplates/j2ee/forge/mods.toml.ft
+++ b/src/main/resources/fileTemplates/j2ee/forge/mods.toml.ft
@@ -29,7 +29,11 @@ updateJSONURL="${UPDATE_URL}" #optional
 #updateJSONURL="https://change.me.example.invalid/updates.json" #optional
 #end
 # A URL for the "homepage" for this mod, displayed in the mod UI
+#if (${WEBSITE})
+displayURL="${WEBSITE}" #optional
+#else
 #displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
+#end
 # A file name (in the root of the mod JAR) containing a logo for display
 #logoFile="${ARTIFACT_ID}.png" #optional
 # A text field displayed in the mod UI


### PR DESCRIPTION
This PR add support for Website field in `mods.toml` file (when field is filled, `displayURL` is no longer commented)