### PR TITLE
Add paths-ignore to CI/CD files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - '*'
+    paths-ignore:
+      - 'readme.md'
+      - '.github/**'
+      - '!.github/workflows/**'
 
 jobs:
   publish:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,16 @@ name: Test
 on:
   push:
     branches: ['*']
+    paths-ignore:
+      - 'readme.md'
+      - '.github/**'
+      - '!.github/workflows/**'
   pull_request:
     branches: ['*']
+    paths-ignore:
+      - 'readme.md'
+      - '.github/**'
+      - '!.github/workflows/**'
 
 jobs:
   build:


### PR DESCRIPTION
This PR add paths-ignore field to not trigger Github Actions when a PR/commit modify only files included.

For example : if a PR/commit modify readme.md file and only them, Actions are not trigger but if it modifies another file at the same time as the readme.md, Actions are triggered.

In this list, only readme.md & files in `.github` folder (except files in the folder `.github/workflows`).

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths