### PR TITLE
Add basic support for MixinExtras Sugar

### DIFF
--- a/src/main/kotlin/platform/mixin/util/Mixin.kt
+++ b/src/main/kotlin/platform/mixin/util/Mixin.kt
@@ -30,6 +30,7 @@ import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiDisjunctionType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiIntersectionType
+import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
 import com.intellij.psi.search.GlobalSearchScope
@@ -119,6 +120,11 @@ val PsiClass.isAccessorMixin: Boolean
 
         val targets = mixinTargets
         return targets.isNotEmpty() && !targets.any { it.hasAccess(Opcodes.ACC_INTERFACE) }
+    }
+
+val PsiParameter.isMixinExtrasSugar: Boolean
+    get() {
+        return annotations.any { it.qualifiedName?.contains(".mixinextras.sugar.") == true }
     }
 
 fun callbackInfoType(project: Project): PsiType =

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
@@ -31,6 +31,10 @@ class InvalidInjectorMethodSignatureFixTest : BaseMixinTest() {
     fun simpleCase() = doTest("simpleCase")
 
     @Test
+    @DisplayName("Simple case with MixinExtras Sugar")
+    fun simpleCaseWithMixinExtrasSugar() = doTest("simpleCaseWithMixinExtrasSugar")
+
+    @Test
     @DisplayName("With captured locals")
     fun withCapturedLocals() = doTest("withCapturedLocals")
 

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCaseWithMixinExtrasSugar.after.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCaseWithMixinExtrasSugar.after.java
@@ -1,0 +1,16 @@
+package test;
+
+import com.demonwav.mcdev.mixintestdata.invalidInjectorMethodSignatureFix.MixedInSimple;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, int i, CallbackInfo ci, @Local String str<caret>) {
+    }
+}

--- a/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCaseWithMixinExtrasSugar.java
+++ b/src/test/resources/com/demonwav/mcdev/platform/mixin/invalidInjectorMethodSignature/simpleCaseWithMixinExtrasSugar.java
@@ -1,0 +1,16 @@
+package test;
+
+import com.demonwav.mcdev.mixintestdata.invalidInjectorMethodSignatureFix.MixedInSimple;
+import com.llamalad7.mixinextras.sugar.Local;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MixedInSimple.class)
+public class TestMixin {
+
+    @Inject(method = "simpleMethod", at = @At("RETURN"))
+    private void injectCtor(String string, CallbackInfo ci, @Local String str<caret>) {
+    }
+}


### PR DESCRIPTION
[Sugar](https://github.com/LlamaLad7/MixinExtras/wiki/Sugar) breaks the normal rules of what is allowed in handler method parameters so special treatment is needed in MCDev.

This PR does *not* support any other areas of MixinExtras, or actually validate any of the sugars, it simply ensures they do not trigger errors and are preserved by quick fixes. I still plan to PR better support for the library as a whole in future, but this is more important for the time being as it is kind of crucial to the feature's adoption.

There are quite a few pre-relocated versions of MixinExtras floating around so the class name check is as generic as possible.