### PR TITLE
Fix FG2 gradle model not being instantiated

### DIFF
--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelFG2Impl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelFG2Impl.groovy
@@ -13,7 +13,7 @@ package com.demonwav.mcdev.platform.mcp.gradle.tooling
 import groovy.transform.CompileStatic
 
 @CompileStatic
-final class McpModelFG2Impl implements McpModel, Serializable {
+final class McpModelFG2Impl implements McpModelFG2, Serializable {
 
     final String minecraftVersion
     final String mcpVersion


### PR DESCRIPTION
In `src/main/kotlin/platform/mcp/gradle/datahandler/McpModelFG2Handler.kt` line 30, `resolverCtx.getExtraProject(gradleModule, McpModelFG2::class.java)` is used to obtain the FG2 Mcp model from the gradle plugin. However, the gradle plugin for FG2 did not implement `McpModelFG2` but only the superinterface `McpModel` which made that handler never activate.