### PR TITLE
Improved Copy AW Entry for constructors

### DIFF
--- a/src/main/kotlin/platform/mcp/actions/CopyAwAction.kt
+++ b/src/main/kotlin/platform/mcp/actions/CopyAwAction.kt
@@ -68,7 +68,7 @@ class CopyAwAction : AnAction() {
                     val containing = target.containingClass?.internalName
                         ?: return maybeShow("Could not get owner of method", e)
                     val desc = target.descriptor ?: return maybeShow("Could not get descriptor of method", e)
-                    val text = "accessible method $containing ${target.name} $desc"
+                    val text = "accessible method $containing ${target.internalName} $desc"
                     copyToClipboard(editor, element, text)
                 }
                 else -> maybeShow("Invalid element", e)

--- a/src/main/kotlin/platform/mcp/actions/SrgActionBase.kt
+++ b/src/main/kotlin/platform/mcp/actions/SrgActionBase.kt
@@ -29,6 +29,7 @@ import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiReference
 import com.intellij.ui.LightColors
 import com.intellij.ui.awt.RelativePoint
+import org.apache.commons.lang.StringEscapeUtils
 
 abstract class SrgActionBase : AnAction() {
 
@@ -91,8 +92,9 @@ abstract class SrgActionBase : AnAction() {
         }
 
         fun showSuccessBalloon(editor: Editor, element: PsiElement, text: String) {
+            val escapedText = StringEscapeUtils.escapeHtml(text)
             val balloon = JBPopupFactory.getInstance()
-                .createHtmlTextBalloonBuilder(text, null, LightColors.SLIGHTLY_GREEN, null)
+                .createHtmlTextBalloonBuilder(escapedText, null, LightColors.SLIGHTLY_GREEN, null)
                 .setHideOnAction(true)
                 .setHideOnClickOutside(true)
                 .setHideOnKeyOutside(true)

--- a/src/main/kotlin/util/bytecode-utils.kt
+++ b/src/main/kotlin/util/bytecode-utils.kt
@@ -17,10 +17,12 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.TypeConversionUtil
+import org.jetbrains.plugins.groovy.lang.resolve.processors.inference.type
 
 private const val INTERNAL_CONSTRUCTOR_NAME = "<init>"
 
@@ -149,6 +151,13 @@ val PsiMethod.descriptor: String?
 @Throws(ClassNameResolutionFailedException::class)
 private fun PsiMethod.appendDescriptor(builder: StringBuilder): StringBuilder {
     builder.append('(')
+    if (isConstructor) {
+        containingClass?.let { containingClass ->
+            if (containingClass.hasModifierProperty(PsiModifier.STATIC)) return@let
+            val outerClass = containingClass.containingClass
+            outerClass?.type()?.appendDescriptor(builder)
+        }
+    }
     for (parameter in parameterList.parameters) {
         parameter.type.appendDescriptor(builder)
     }


### PR DESCRIPTION
- Uses `<init>` for method name, fixes #1935

- Include outer class type in descriptor for inner class constructor