### PR TITLE
Make Gradle 7.6.1 Default Gradle

### DIFF
--- a/src/main/kotlin/creator/buildsystem/gradle-steps.kt
+++ b/src/main/kotlin/creator/buildsystem/gradle-steps.kt
@@ -48,7 +48,7 @@ import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
 import org.jetbrains.plugins.gradle.service.project.open.canLinkAndRefreshGradleProject
 import org.jetbrains.plugins.gradle.service.project.open.linkAndRefreshGradleProject
 
-val DEFAULT_GRADLE_VERSION = SemanticVersion.release(7, 3, 3)
+val DEFAULT_GRADLE_VERSION = SemanticVersion.release(7, 6, 1)
 val GRADLE_VERSION_KEY = Key.create<SemanticVersion>("mcdev.gradleVersion")
 
 fun FixedAssetsNewProjectWizardStep.addGradleWrapperProperties(project: Project) {


### PR DESCRIPTION
Current Default is 7.3.3 Which at this point is outdated by Gradle 7 Standards and doesn't support Java 18 and 19.  Gradle 7.6.1 is the latest with 7.6 being the last major 7.X version being released.