### PR TITLE
Delete LiteLoader related code

### DIFF
--- a/src/main/kotlin/asset/PlatformAssets.kt
+++ b/src/main/kotlin/asset/PlatformAssets.kt
@@ -47,9 +47,6 @@ object PlatformAssets : Assets() {
     val VELOCITY_ICON = loadIcon("/assets/icons/platform/Velocity.png")
     val VELOCITY_ICON_2X = loadIcon("/assets/icons/platform/Velocity@2x.png")
 
-    val LITELOADER_ICON = loadIcon("/assets/icons/platform/LiteLoader.png")
-    val LITELOADER_ICON_2X = loadIcon("/assets/icons/platform/LiteLoader@2x.png")
-
     val MIXIN_ICON = loadIcon("/assets/icons/platform/Mixins.png")
     val MIXIN_ICON_2X = loadIcon("/assets/icons/platform/Mixins@2x.png")
     val MIXIN_ICON_DARK = loadIcon("/assets/icons/platform/Mixins_dark.png")

--- a/src/main/kotlin/util/MinecraftTemplates.kt
+++ b/src/main/kotlin/util/MinecraftTemplates.kt
@@ -94,14 +94,6 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
             fabricGroup.addTemplate(FileTemplateDescriptor(FABRIC_SETTINGS_GRADLE_TEMPLATE, PlatformAssets.FABRIC_ICON))
         }
 
-        FileTemplateGroupDescriptor("LiteLoader", PlatformAssets.LITELOADER_ICON).let { liteGroup ->
-            group.addTemplate(liteGroup)
-            liteGroup.addTemplate(FileTemplateDescriptor(LITELOADER_MAIN_CLASS_TEMPLATE))
-            liteGroup.addTemplate(FileTemplateDescriptor(LITELOADER_BUILD_GRADLE_TEMPLATE))
-            liteGroup.addTemplate(FileTemplateDescriptor(LITELOADER_GRADLE_PROPERTIES_TEMPLATE))
-            liteGroup.addTemplate(FileTemplateDescriptor(LITELOADER_SETTINGS_GRADLE_TEMPLATE))
-        }
-
         FileTemplateGroupDescriptor("Multi-Module", PlatformAssets.MINECRAFT_ICON).let { multiGroup ->
             group.addTemplate(multiGroup)
             multiGroup.addTemplate(FileTemplateDescriptor(MULTI_MODULE_BUILD_GRADLE_TEMPLATE))
@@ -228,11 +220,6 @@ class MinecraftTemplates : FileTemplateGroupDescriptorFactory {
         const val ARCHITECTURY_FORGE_MIXINS_JSON_TEMPLATE = "architectury_forge_mixins.json"
         const val ARCHITECTURY_FORGE_MODS_TOML_TEMPLATE = "architectury_forge_mods.toml"
         const val ARCHITECTURY_FORGE_PACK_MCMETA_TEMPLATE = "architectury_forge_pack.mcmeta"
-
-        const val LITELOADER_MAIN_CLASS_TEMPLATE = "LiteLoader Main Class.java"
-        const val LITELOADER_BUILD_GRADLE_TEMPLATE = "LiteLoader build.gradle"
-        const val LITELOADER_GRADLE_PROPERTIES_TEMPLATE = "LiteLoader gradle.properties"
-        const val LITELOADER_SETTINGS_GRADLE_TEMPLATE = "LiteLoader settings.gradle"
 
         const val MULTI_MODULE_BUILD_GRADLE_TEMPLATE = "Multi-Module Base build.gradle"
         const val MULTI_MODULE_GRADLE_PROPERTIES_TEMPLATE = "Multi-Module Base gradle.properties"


### PR DESCRIPTION
I kept the icons because they are used in the MinecraftFacetEditorTab file (I don't know what this interface is for anyway).

https://github.com/minecraft-dev/MinecraftDev/blob/dev/src/main/kotlin/facet/MinecraftFacetEditorTab.form

https://github.com/minecraft-dev/MinecraftDev/commit/83949ccec33f5900f9afa7453acfd67b84f16454#diff-17a50e2cc17da4fad88df7776925039217043b0f464d8dad2265379ae0e1a57d