### PR TITLE
Replace classifier with archiveClassifier.set()

### DIFF
--- a/src/main/resources/fileTemplates/j2ee/architectury/architectury_fabric_build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/architectury/architectury_fabric_build.gradle.ft
@@ -39,17 +39,17 @@ processResources {
 
 shadowJar {
     configurations = [project.configurations.shadowCommon]
-    classifier "dev-shadow"
+    archiveClassifier.set("dev-shadow")
 }
 
 remapJar {
     inputFile.set shadowJar.archiveFile
     dependsOn shadowJar
-    classifier null
+    archiveClassifier.set(null)
 }
 
 jar {
-    classifier "dev"
+    archiveClassifier.set("dev")
 }
 
 sourcesJar {

--- a/src/main/resources/fileTemplates/j2ee/architectury/architectury_forge_build.gradle.ft
+++ b/src/main/resources/fileTemplates/j2ee/architectury/architectury_forge_build.gradle.ft
@@ -45,17 +45,17 @@ shadowJar {
     exclude "fabric.mod.json"
 
     configurations = [project.configurations.shadowCommon]
-    classifier "dev-shadow"
+    archiveClassifier.set("dev-shadow")
 }
 
 remapJar {
     inputFile.set shadowJar.archiveFile
     dependsOn shadowJar
-    classifier null
+    archiveClassifier.set(null)
 }
 
 jar {
-    classifier "dev"
+    archiveClassifier.set("dev")
 }
 
 sourcesJar {


### PR DESCRIPTION
Classifier is deprecated in Shadow 7 and is marked for removal
New way is archiveClassifier.set() so I replaced them with the new way in the arch files as that's the only place they are used