### PR TITLE
Remap lines lazily in mixin targets that have not been decompiled yet

### DIFF
--- a/src/main/kotlin/platform/mixin/debug/MixinPositionManager.kt
+++ b/src/main/kotlin/platform/mixin/debug/MixinPositionManager.kt
@@ -29,6 +29,7 @@ import com.intellij.debugger.NoDataException
 import com.intellij.debugger.SourcePosition
 import com.intellij.debugger.engine.DebugProcess
 import com.intellij.debugger.engine.DebuggerUtils
+import com.intellij.debugger.engine.PositionManagerImpl.ClsSourcePosition
 import com.intellij.debugger.impl.DebuggerUtilsEx
 import com.intellij.debugger.requests.ClassPrepareRequestor
 import com.intellij.ide.highlighter.JavaFileType
@@ -82,6 +83,9 @@ class MixinPositionManager(private val debugProcess: DebugProcess) : MultiReques
                     val adjustedLine = DebuggerUtilsEx.bytecodeToSourceLine(psiFile, line)
                     if (adjustedLine > -1) {
                         line = adjustedLine
+                    } else {
+                        // Class is not decompiled yet, return a lazily remapped SourcePosition
+                        return ClsSourcePosition(SourcePosition.createFromLine(psiFile, line), line)
                     }
                 }
 


### PR DESCRIPTION
Fixes https://github.com/minecraft-dev/MinecraftDev/issues/2026#issuecomment-1537493401. Well, mostly.

Prior to this commit, switching to a stack frame inside a not yet decompiled class would take you to the wrong line, and switching to the same stack frame would always take you to the same wrong line until you restart the debug session.

With this commit, the first time you switch, you will still be taken to the wrong line, but on subsequent switches you will be taken to the correct line. The same thing happens even without the plugin, so I assume this is just a limitation of IntelliJ that can't be helped.