### PR TITLE
Fix fabric config inspection error

### DIFF
--- a/src/main/kotlin/platform/fabric/util/FabricConstants.kt
+++ b/src/main/kotlin/platform/fabric/util/FabricConstants.kt
@@ -27,7 +27,7 @@ object FabricConstants {
     const val MOD_INITIALIZER = "net.fabricmc.api.ModInitializer"
     const val CLIENT_MOD_INITIALIZER = "net.fabricmc.api.ClientModInitializer"
     const val SERVER_MOD_INITIALIZER = "net.fabricmc.api.DedicatedServerModInitializer"
-    const val PRE_LAUNCH_ENTRYPOINT = "net.fabricmc.loader.api.entrypoint.PreLaunchEntryPoint"
+    const val PRE_LAUNCH_ENTRYPOINT = "net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint"
     const val ENVIRONMENT_ANNOTATION = "net.fabricmc.api.Environment"
     const val ENV_TYPE = "net.fabricmc.api.EnvType"
     const val ENVIRONMENT_INTERFACE_ANNOTATION = "net.fabricmc.api.EnvironmentInterface"


### PR DESCRIPTION
This PR fixes a typo that would trigger the following inspection even when the interface is being used: 

![image](https://github.com/minecraft-dev/MinecraftDev/assets/43681932/9fb9bd4c-274b-4e4f-b92a-44d1446fb309)
https://github.com/FabricMC/fabric-loader/blob/master/src/main/java/net/fabricmc/loader/api/entrypoint/PreLaunchEntrypoint.java