### PR TITLE
removed <createDependencyReducedPom> setting from default bukkit and bungeecord pom.xml templates

### DIFF
--- a/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit pom.xml.ft
+++ b/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit pom.xml.ft
@@ -37,9 +37,6 @@
             <goals>
               <goal>shade</goal>
             </goals>
-            <configuration>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/resources/fileTemplates/j2ee/bungeecord/BungeeCord pom.xml.ft
+++ b/src/main/resources/fileTemplates/j2ee/bungeecord/BungeeCord pom.xml.ft
@@ -38,9 +38,6 @@
             <goals>
               <goal>shade</goal>
             </goals>
-            <configuration>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This PR removes the `<createDependencyReducedPom>` option from the default pom files for Bukkit and Bungeecord because:

1. It has no advantage to disable the creation of dependeny-reduced-pom.xml
2. Disabling the creation of it causes shaded dependencies to become transitive dependencies to other projects that depend on this project. [See here for a short explanation](https://blog.jeff-media.com/dont-disable-dependency-reduced-xml/)

The default .gitignore for maven projects already contains an entry for dependency-reduced-pom.xml so no further changes are needed there.