### PR TITLE
Add external annotations to Minecraft libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.gradle.ext.settings
 import org.jetbrains.gradle.ext.taskTriggers
+import org.jetbrains.intellij.tasks.PrepareSandboxTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.tasks.BaseKtLintCheckTask
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
@@ -70,6 +71,12 @@ val gradleToolingExtensionSourceSet: SourceSet = sourceSets.create("gradle-tooli
 val gradleToolingExtensionJar = tasks.register<Jar>(gradleToolingExtensionSourceSet.jarTaskName) {
     from(gradleToolingExtensionSourceSet.output)
     archiveClassifier.set("gradle-tooling-extension")
+}
+
+val externalAnnotationsJar = tasks.register<Jar>("externalAnnotationsJar") {
+    from("externalAnnotations")
+    destinationDirectory.set(layout.buildDirectory.dir("externalAnnotations"))
+    archiveFileName.set("externalAnnotations.jar")
 }
 
 repositories {
@@ -298,6 +305,9 @@ license {
         register("grammars") {
             files.from(project.fileTree("src/main/grammars"))
         }
+        register("externalAnnotations") {
+            files.from(project.fileTree("externalAnnotations"))
+        }
     }
 }
 
@@ -354,6 +364,12 @@ tasks.register("cleanSandbox", Delete::class) {
     group = "intellij"
     description = "Deletes the sandbox directory."
     delete(layout.projectDirectory.dir(".sandbox"))
+}
+
+tasks.withType<PrepareSandboxTask> {
+    from(externalAnnotationsJar) {
+        into("Minecraft Development/lib/resources")
+    }
 }
 
 tasks.runIde {

--- a/externalAnnotations/com/mojang/blaze3d/platform/annotations.xml
+++ b/externalAnnotations/com/mojang/blaze3d/platform/annotations.xml
@@ -1,0 +1,25 @@
+<!--
+    Minecraft Development for IntelliJ
+
+    https://mcdev.io/
+
+    Copyright (C) 2023 minecraft-dev
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, version 3.0 only.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<root>
+    <item name="com.mojang.blaze3d.platform.InputConstants com.mojang.blaze3d.platform.InputConstants.Key getKey(java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+</root>

--- a/externalAnnotations/net/minecraft/client/annotations.xml
+++ b/externalAnnotations/net/minecraft/client/annotations.xml
@@ -1,0 +1,58 @@
+<!--
+    Minecraft Development for IntelliJ
+
+    https://mcdev.io/
+
+    Copyright (C) 2023 minecraft-dev
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, version 3.0 only.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<root>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, int, java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, int, java.lang.String) 2">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, com.mojang.blaze3d.platform.InputConstants.Type, int, java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, com.mojang.blaze3d.platform.InputConstants.Type, int, java.lang.String) 3">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, com.mojang.blaze3d.platform.InputConstants.Type, int, java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, com.mojang.blaze3d.platform.InputConstants.Type, int, java.lang.String) 4">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, com.mojang.blaze3d.platform.InputConstants.Key, java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, com.mojang.blaze3d.platform.InputConstants.Key, java.lang.String) 3">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, net.minecraftforge.client.settings.KeyModifier, com.mojang.blaze3d.platform.InputConstants.Type, int, java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, net.minecraftforge.client.settings.KeyModifier, com.mojang.blaze3d.platform.InputConstants.Type, int, java.lang.String) 5">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, net.minecraftforge.client.settings.KeyModifier, com.mojang.blaze3d.platform.InputConstants.Key, java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.client.KeyMapping KeyMapping(java.lang.String, net.minecraftforge.client.settings.IKeyConflictContext, net.minecraftforge.client.settings.KeyModifier, com.mojang.blaze3d.platform.InputConstants.Key, java.lang.String) 4">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+</root>

--- a/externalAnnotations/net/minecraft/client/resources/language/annotations.xml
+++ b/externalAnnotations/net/minecraft/client/resources/language/annotations.xml
@@ -1,0 +1,30 @@
+<!--
+    Minecraft Development for IntelliJ
+
+    https://mcdev.io/
+
+    Copyright (C) 2023 minecraft-dev
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, version 3.0 only.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<root>
+    <item name="net.minecraft.client.resources.language.I18n java.lang.String get(java.lang.String, java.lang.Object...) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable">
+            <val name="foldMethod" val="true"/>
+        </annotation>
+    </item>
+    <item name="net.minecraft.client.resources.language.I18n boolean exists(java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+</root>

--- a/externalAnnotations/net/minecraft/command/annotations.xml
+++ b/externalAnnotations/net/minecraft/command/annotations.xml
@@ -1,0 +1,25 @@
+<!--
+    Minecraft Development for IntelliJ
+
+    https://mcdev.io/
+
+    Copyright (C) 2023 minecraft-dev
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, version 3.0 only.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<root>
+    <item name="net.minecraft.command.CommandException CommandException(java.lang.String, java.lang.Object...) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+</root>

--- a/externalAnnotations/net/minecraft/network/chat/annotations.xml
+++ b/externalAnnotations/net/minecraft/network/chat/annotations.xml
@@ -1,0 +1,48 @@
+<!--
+    Minecraft Development for IntelliJ
+
+    https://mcdev.io/
+
+    Copyright (C) 2023 minecraft-dev
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, version 3.0 only.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<root>
+    <item name="net.minecraft.network.chat.TranslatableComponent TranslatableComponent(java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable">
+            <val name="foldMethod" val="true"/>
+        </annotation>
+    </item>
+    <item name="net.minecraft.network.chat.TranslatableComponent TranslatableComponent(java.lang.String, java.lang.Object...) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable">
+            <val name="foldMethod" val="true"/>
+        </annotation>
+    </item>
+    <item name="net.minecraft.network.chat.Component net.minecraft.network.chat.MutableComponent translatable(java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable">
+            <val name="foldMethod" val="true"/>
+        </annotation>
+    </item>
+    <item name="net.minecraft.network.chat.Component net.minecraft.network.chat.MutableComponent translatable(java.lang.String, java.lang.Object...) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable">
+            <val name="foldMethod" val="true"/>
+        </annotation>
+    </item>
+    <item name="net.minecraft.network.chat.Component net.minecraft.network.chat.MutableComponent translatableWithFallback(java.lang.String, java.lang.String) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+    <item name="net.minecraft.network.chat.Component net.minecraft.network.chat.MutableComponent translatableWithFallback(java.lang.String, java.lang.String, java.lang.Object...) 0">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+</root>

--- a/externalAnnotations/net/minecraftforge/server/command/annotations.xml
+++ b/externalAnnotations/net/minecraftforge/server/command/annotations.xml
@@ -1,0 +1,25 @@
+<!--
+    Minecraft Development for IntelliJ
+
+    https://mcdev.io/
+
+    Copyright (C) 2023 minecraft-dev
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, version 3.0 only.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<root>
+    <item name="net.minecraftforge.server.command.TextComponentHelper net.minecraft.network.chat.BaseComponent createComponentTranslation(net.minecraft.commands.CommandSource, java.lang.String, java.lang.Object...) 1">
+        <annotation name="com.demonwav.mcdev.annotations.Translatable"/>
+    </item>
+</root>

--- a/src/main/kotlin/facet/ProjectReimporter.kt
+++ b/src/main/kotlin/facet/ProjectReimporter.kt
@@ -33,7 +33,7 @@ import com.intellij.openapi.project.Project
 object ProjectReimporter {
     private val log = logger<ProjectReimporter>()
 
-    const val CURRENT_REIMPORT_VERSION = 0
+    const val CURRENT_REIMPORT_VERSION = 1
 
     fun needsReimport(facet: MinecraftFacet) =
         facet.configuration.state.projectReimportVersion < CURRENT_REIMPORT_VERSION

--- a/src/main/kotlin/translations/identification/TranslationAnnotationsLocationProvider.kt
+++ b/src/main/kotlin/translations/identification/TranslationAnnotationsLocationProvider.kt
@@ -1,0 +1,48 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2023 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.translations.identification
+
+import com.demonwav.mcdev.platform.mcp.framework.MCP_LIBRARY_KIND
+import com.intellij.codeInsight.externalAnnotation.location.AnnotationsLocation
+import com.intellij.codeInsight.externalAnnotation.location.AnnotationsLocationProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.roots.libraries.Library
+import com.intellij.openapi.roots.ui.configuration.libraries.LibraryPresentationManager
+
+class TranslationAnnotationsLocationProvider : AnnotationsLocationProvider {
+    override fun getLocations(
+        project: Project,
+        library: Library,
+        artifactId: String?,
+        groupId: String?,
+        version: String?
+    ): Collection<AnnotationsLocation> {
+        val isMinecraftLibrary = LibraryPresentationManager.getInstance().isLibraryOfKind(
+            library.getFiles(OrderRootType.CLASSES).toList(),
+            MCP_LIBRARY_KIND
+        )
+        if (isMinecraftLibrary) {
+            return listOf(TranslationExternalAnnotationsArtifactsResolver.Util.fakeMavenLocation)
+        }
+        return emptyList()
+    }
+}

--- a/src/main/kotlin/translations/identification/TranslationExternalAnnotationsArtifactsResolver.kt
+++ b/src/main/kotlin/translations/identification/TranslationExternalAnnotationsArtifactsResolver.kt
@@ -1,0 +1,130 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2023 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.translations.identification
+
+import com.demonwav.mcdev.util.invokeAndWait
+import com.demonwav.mcdev.util.invokeLater
+import com.intellij.codeInsight.ExternalAnnotationsArtifactsResolver
+import com.intellij.codeInsight.externalAnnotation.location.AnnotationsLocation
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.AnnotationOrderRootType
+import com.intellij.openapi.roots.impl.libraries.LibraryEx
+import com.intellij.openapi.roots.libraries.Library
+import com.intellij.openapi.roots.libraries.ui.OrderRoot
+import com.intellij.openapi.roots.ui.configuration.libraryEditor.ExistingLibraryEditor
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import org.jetbrains.concurrency.AsyncPromise
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.resolvedPromise
+
+class TranslationExternalAnnotationsArtifactsResolver : ExternalAnnotationsArtifactsResolver {
+    override fun resolve(project: Project, library: Library, mavenId: String?): Boolean {
+        if (!Util.isOurFakeMavenLocation(mavenId)) {
+            return false
+        }
+
+        return invokeAndWait {
+            doResolve(library)
+        }
+    }
+
+    override fun resolve(project: Project, library: Library, annotationsLocation: AnnotationsLocation): Boolean {
+        if (annotationsLocation != Util.fakeMavenLocation) {
+            return false
+        }
+        return invokeAndWait {
+            doResolve(library)
+        }
+    }
+
+    override fun resolveAsync(project: Project, library: Library, mavenId: String?): Promise<Library> {
+        if (!Util.isOurFakeMavenLocation(mavenId)) {
+            return resolvedPromise(library)
+        }
+
+        val promise = AsyncPromise<Library>()
+        ApplicationManager.getApplication().executeOnPooledThread {
+            invokeLater {
+                doResolve(library)
+                promise.setResult(library)
+            }
+        }
+
+        return promise
+    }
+
+    private fun doResolve(library: Library): Boolean {
+        if (library !is LibraryEx || library.isDisposed) {
+            return false
+        }
+
+        return runWriteAction {
+            val annotationsPath = findAnnotationsPath(false)
+                ?: findAnnotationsPath(true)
+                ?: return@runWriteAction false
+
+            val editor = ExistingLibraryEditor(library, null)
+            val type = AnnotationOrderRootType.getInstance()
+            editor.getUrls(type).forEach { editor.removeRoot(it, type) }
+            editor.addRoots(listOf(OrderRoot(annotationsPath, type)))
+            editor.commit()
+
+            true
+        }
+    }
+
+    private fun findAnnotationsPath(refresh: Boolean): VirtualFile? {
+        val mcdevClassesRootPath =
+            PathManager.getJarForClass(TranslationExternalAnnotationsArtifactsResolver::class.java)?.toAbsolutePath()
+        if (!log.assertTrue(mcdevClassesRootPath != null)) {
+            return null
+        }
+        mcdevClassesRootPath!!
+
+        val vfm = VirtualFileManager.getInstance()
+        val annotationsJarPath = mcdevClassesRootPath.resolveSibling("resources/externalAnnotations.jar")
+        val annotationsJarPathString = FileUtil.toSystemIndependentName(annotationsJarPath.toString())
+        val url = "jar://$annotationsJarPathString!/"
+        return if (refresh) {
+            vfm.refreshAndFindFileByUrl(url)
+        } else {
+            vfm.findFileByUrl(url)
+        }
+    }
+
+    companion object {
+        val log = logger<TranslationExternalAnnotationsArtifactsResolver>()
+    }
+
+    object Util {
+        val fakeMavenLocation = AnnotationsLocation("com.demonwav.mcdev", "external_annotations", "1.0")
+
+        fun isOurFakeMavenLocation(mavenId: String?): Boolean {
+            return mavenId == "com.demonwav.mcdev:external_annotations:1.0"
+        }
+    }
+}

--- a/src/main/kotlin/translations/identification/TranslationExternalAnnotationsArtifactsResolver.kt
+++ b/src/main/kotlin/translations/identification/TranslationExternalAnnotationsArtifactsResolver.kt
@@ -89,7 +89,6 @@ class TranslationExternalAnnotationsArtifactsResolver : ExternalAnnotationsArtif
 
             val editor = ExistingLibraryEditor(library, null)
             val type = AnnotationOrderRootType.getInstance()
-            editor.getUrls(type).forEach { editor.removeRoot(it, type) }
             editor.addRoots(listOf(OrderRoot(annotationsPath, type)))
             editor.commit()
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -264,6 +264,8 @@
                                order="before javaSkipAutopopupInStrings"/>
         <fileBasedIndex implementation="com.demonwav.mcdev.translations.index.TranslationIndex"/>
         <fileBasedIndex implementation="com.demonwav.mcdev.translations.index.TranslationInverseIndex"/>
+        <java.externalAnnotation.locationProvider implementation="com.demonwav.mcdev.translations.identification.TranslationAnnotationsLocationProvider"/>
+        <externalAnnotationsArtifactsResolver implementation="com.demonwav.mcdev.translations.identification.TranslationExternalAnnotationsArtifactsResolver" order="first"/>
 
         <applicationService serviceImplementation="com.demonwav.mcdev.MinecraftSettings"/>
 


### PR DESCRIPTION
This is to support a switch to using a `@Translatable` annotation for translation inspections. See https://github.com/minecraft-dev/annotations/pull/1.

Note that this is not to support general addition or removal of annotations to the Minecraft code (such as removing `@Deprecated` from the `Block` class), only those to support MinecraftDev. General addition or removal is in my opinion better suited in other projects such as Parchment and Yarn.