### PR TITLE
Fix DefaultAnnotationParamInspectionSuppressor

### DIFF
--- a/src/main/kotlin/platform/mixin/inspection/suppress/DefaultAnnotationParamInspectionSuppressor.kt
+++ b/src/main/kotlin/platform/mixin/inspection/suppress/DefaultAnnotationParamInspectionSuppressor.kt
@@ -20,16 +20,14 @@
 
 package com.demonwav.mcdev.platform.mixin.inspection.suppress
 
+import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.ACCESSOR
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.CONSTANT
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.INJECT
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.INVOKER
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MIXIN
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MODIFY_ARG
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MODIFY_ARGS
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MODIFY_VARIABLE
-import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.REDIRECT
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.OVERWRITE
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.SHADOW
 import com.demonwav.mcdev.util.constantValue
 import com.demonwav.mcdev.util.findAnnotation
 import com.demonwav.mcdev.util.mapFirstNotNull
@@ -41,6 +39,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiModifierListOwner
 import com.intellij.psi.PsiNameValuePair
 import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.parentsOfType
 
 class DefaultAnnotationParamInspectionSuppressor : InspectionSuppressor {
     override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean {
@@ -55,21 +54,23 @@ class DefaultAnnotationParamInspectionSuppressor : InspectionSuppressor {
             return true
         }
 
-        if (name == "remap" && REMAP_SUPPRESSED.any(annotation::hasQualifiedName)) {
+        if (name == "remap" && annotation.hasRemap) {
             val currentRemap = annotation.findAttributeValue("remap")?.constantValue as? Boolean
                 ?: return false
-            val parentRemap = generateSequence<PsiElement>(annotation) { elem ->
+            var parents = annotation.parentsOfType<PsiAnnotation>(withSelf = false).filter { it.hasRemap }
+            parents += generateSequence<PsiElement>(annotation) { elem ->
                 elem.parent?.takeIf { elem !is PsiClass }
             }
                 .filterIsInstance<PsiModifierListOwner>()
                 .drop(1) // don't look at our own owner
                 .mapNotNull { annotationOwner ->
-                    REMAP_SUPPRESSED.mapFirstNotNull {
-                        annotationOwner.findAnnotation(it)?.findDeclaredAttributeValue("remap")?.constantValue
-                            as? Boolean
+                    HAS_REMAP.mapFirstNotNull {
+                        annotationOwner.findAnnotation(it)
                     }
                 }
-                .firstOrNull() ?: true
+            val parentRemap = parents.firstNotNullOfOrNull {
+                it.findDeclaredAttributeValue("remap")?.constantValue as? Boolean
+            } ?: true
             if (currentRemap != parentRemap) {
                 return true
             }
@@ -78,22 +79,22 @@ class DefaultAnnotationParamInspectionSuppressor : InspectionSuppressor {
         return false
     }
 
+    private val PsiAnnotation.hasRemap get() = qualifiedName?.let { it in HAS_REMAP } == true
+
     override fun getSuppressActions(element: PsiElement?, toolId: String): Array<SuppressQuickFix> =
         SuppressQuickFix.EMPTY_ARRAY
 
     companion object {
         private const val INSPECTION = "DefaultAnnotationParam"
-        private val REMAP_SUPPRESSED = setOf(
-            AT,
-            INJECT,
-            MODIFY_ARG,
-            MODIFY_ARGS,
-            MODIFY_VARIABLE,
-            REDIRECT,
-            ACCESSOR,
-            INVOKER,
-            MIXIN,
-        )
+        private val HAS_REMAP = buildSet {
+            add(MIXIN)
+            add(AT)
+            add(ACCESSOR)
+            add(INVOKER)
+            add(OVERWRITE)
+            add(SHADOW)
+            addAll(MixinAnnotationHandler.getBuiltinHandlers().map { it.first })
+        }
         private val CONSTANT_SUPPRESSED = setOf(
             "intValue",
             "floatValue",


### PR DESCRIPTION
It previously didn't take into account direct parents of the current annotation, i.e. injector annotations for `@At`s. It also wouldn't have worked for custom injectors because it hardcoded the available annotations.