### PR TITLE
MixinExtras: Add support for `@WrapOperation`s targeting instantiations.

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/MixinExtrasInjectorAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/MixinExtrasInjectorAnnotationHandler.kt
@@ -21,6 +21,7 @@
 package com.demonwav.mcdev.platform.mixin.handlers.mixinextras
 
 import com.demonwav.mcdev.platform.mixin.handlers.InjectorAnnotationHandler
+import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.NewInsnInjectionPoint
 import com.demonwav.mcdev.platform.mixin.inspection.injector.MethodSignature
 import com.demonwav.mcdev.platform.mixin.inspection.injector.ParameterGroup
 import com.demonwav.mcdev.platform.mixin.util.FieldTargetMember
@@ -219,7 +220,7 @@ abstract class MixinExtrasInjectorAnnotationHandler : InjectorAnnotationHandler(
                         .resolveAsm(annotation.project) as? MethodTargetMember
                     )?.classAndMethod
                 val parameters = mutableListOf<Parameter>()
-                if (insn.opcode != Opcodes.INVOKESTATIC) {
+                if (insn.opcode != Opcodes.INVOKESTATIC && insn.name != "<init>") {
                     val receiver = if (insn.opcode == Opcodes.INVOKESPECIAL && !oldSuperBehavior) {
                         targetClass.name
                     } else {
@@ -269,6 +270,10 @@ abstract class MixinExtrasInjectorAnnotationHandler : InjectorAnnotationHandler(
                 when (insn.opcode) {
                     Opcodes.INSTANCEOF ->
                         listOf(Parameter("object", Type.getType(Any::class.java).toPsiType(elementFactory)))
+
+                    Opcodes.NEW -> NewInsnInjectionPoint.findInitCall(insn)?.let {
+                        getPsiParameters(it, targetClass, annotation)
+                    }
 
                     else -> null
                 }

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapOperationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapOperationHandler.kt
@@ -35,7 +35,8 @@ import org.objectweb.asm.tree.MethodNode
 
 class WrapOperationHandler : MixinExtrasInjectorAnnotationHandler() {
     override val supportedInstructionTypes = listOf(
-        InstructionType.METHOD_CALL, InstructionType.FIELD_GET, InstructionType.FIELD_SET, InstructionType.INSTANCEOF
+        InstructionType.METHOD_CALL, InstructionType.FIELD_GET, InstructionType.FIELD_SET, InstructionType.INSTANCEOF,
+        InstructionType.INSTANTIATION
     )
 
     override fun getAtKey(annotation: PsiAnnotation): String {


### PR DESCRIPTION
This feature isn't actually released yet but I'm doing this early so MCDev doesn't complain when people start using it.