### PR TITLE
Mixin tweaks for upcoming MixinExtras feature

### DIFF
--- a/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
@@ -128,10 +128,12 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
 
                         if (possibleSignatures.isEmpty()) {
                             reportedSignature = true
-                            holder.registerProblem(
-                                parameters,
-                                "There are no possible signatures for this injector",
-                            )
+                            if (handler.isUnresolved(annotation) != null) {
+                                holder.registerProblem(
+                                    parameters,
+                                    "There are no possible signatures for this injector",
+                                )
+                            }
                             continue
                         }
 

--- a/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
@@ -20,6 +20,7 @@
 
 package com.demonwav.mcdev.platform.mixin.reference.target
 
+import com.demonwav.mcdev.platform.mixin.handlers.InjectorAnnotationHandler
 import com.demonwav.mcdev.platform.mixin.handlers.MixinAnnotationHandler
 import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.AtResolver
 import com.demonwav.mcdev.platform.mixin.reference.MixinReference
@@ -71,9 +72,13 @@ object TargetReference : PolyReferenceResolver(), MixinReference {
     private fun getTargets(at: PsiAnnotation, forUnresolved: Boolean): List<ClassAndMethodNode>? {
         val (handler, annotation) = generateSequence(at.parent) { it.parent }
             .filterIsInstance<PsiAnnotation>()
+            .flatMap { it.owner?.annotations?.asSequence() ?: emptySequence() }
             .mapNotNull { annotation ->
                 val qName = annotation.qualifiedName ?: return@mapNotNull null
-                MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project)?.let { it to annotation }
+                (
+                    MixinAnnotationHandler.forMixinAnnotation(qName, annotation.project)
+                        as? InjectorAnnotationHandler
+                    )?.let { it to annotation }
             }.firstOrNull() ?: return null
         if (forUnresolved && handler.isSoft) {
             return null


### PR DESCRIPTION
An upcoming feature in MixinExtras will allow you to do things like this:
```java
@Expression("this.window.setPhase('Pre render')")
@Definition(id = "window", at = @At(value = "FIELD", target = "..."))
@Definition(id = "setPhase", at = @At(value = "INVOKE", target = "..."))
@Inject(method = "...", at = @At("MIXINEXTRAS:EXPRESSION"))
private void test(CallbackInfo ci) {
}
```
So this PR implements 2 things:
1. `@At`s inside `@Definition`s receive autocomplete
2. If the injector relies on the `@At` to suggest a signature, it will not register the "no possible signatures" error due to the custom injection point

I thought it reasonable to implement these now because they're fairly simple and don't directly rely on this feature. 2 is arguably a bugfix anyway.
I would like to think about full support for the feature in future but this is the bare minimum to make it not annoying to use.
I am of course open to better implementations of either of these things.