### PR TITLE
Improve Forge `clientSideOnly` support

### DIFF
--- a/src/main/kotlin/toml/platform/forge/ModsTomlSchema.kt
+++ b/src/main/kotlin/toml/platform/forge/ModsTomlSchema.kt
@@ -48,8 +48,7 @@ license="All rights reserved"
 showAsResourcePack=false
 # A URL to refer people to when problems occur with this mod.
 issueTrackerURL="http://my.issue.tracker/"
-# If your mod is purely client-side and has no multiplayer functionality (be it dedicated servers or Open to LAN),
-# set this to true, and Forge will set the correct displayTest for you and skip loading your mod on dedicated servers.
+# If your mod is purely client-side and has no multiplayer functionality (be it dedicated servers or Open to LAN), set this to true, and Forge will set the correct displayTest for you and skip loading your mod on dedicated servers.
 clientSideOnly=false
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]]

--- a/src/main/kotlin/toml/platform/forge/ModsTomlSchema.kt
+++ b/src/main/kotlin/toml/platform/forge/ModsTomlSchema.kt
@@ -48,6 +48,9 @@ license="All rights reserved"
 showAsResourcePack=false
 # A URL to refer people to when problems occur with this mod.
 issueTrackerURL="http://my.issue.tracker/"
+# If your mod is purely client-side and has no multiplayer functionality (be it dedicated servers or Open to LAN),
+# set this to true, and Forge will set the correct displayTest for you and skip loading your mod on dedicated servers.
+clientSideOnly=false
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]]
 # The modid of the mod.
@@ -74,7 +77,7 @@ authors="Love, Cheese and small house plants"
 # IGNORE_ALL_VERSION means that your mod will not cause a red X if it's present on the client or the server. This is a special case and should only be used if your mod has no server component.
 # NONE means that no display test is set on your mod. You need to do this yourself, see IExtensionPoint.DisplayTest for more information. You can define any scheme you wish with this value.
 # IMPORTANT NOTE: this is NOT an instruction as to which environments (CLIENT or DEDICATED SERVER) your mod loads on. Your mod should load (and maybe do nothing!) whereever it finds itself.
-displayTest="MATCH_VERSION" # MATCH_VERSION is the default if nothing is specified (#optional)
+displayTest="MATCH_VERSION" # if nothing is specified, MATCH_VERSION is the default when clientSideOnly=false, otherwise IGNORE_ALL_VERSION when clientSideOnly=true (#optional)
 
 # The description text for the mod (multi line!)
 description='''

--- a/src/main/kotlin/toml/platform/forge/completion/ModsTomlCompletionContributor.kt
+++ b/src/main/kotlin/toml/platform/forge/completion/ModsTomlCompletionContributor.kt
@@ -58,6 +58,7 @@ class ModsTomlCompletionContributor : CompletionContributor() {
         extendBooleanValues("showAsResourcePack")
         extendBooleanValues("logoBlur")
         extendBooleanValues("mandatory")
+        extendBooleanValues("clientSideOnly")
     }
 
     private fun extendKnownValues(key: String, values: Set<String>) =

--- a/src/main/kotlin/toml/platform/forge/inspections/ModsTomlValidationInspection.kt
+++ b/src/main/kotlin/toml/platform/forge/inspections/ModsTomlValidationInspection.kt
@@ -112,6 +112,16 @@ class ModsTomlValidationInspection : LocalInspectionTool() {
                         holder.registerProblem(value, TextRange(1, endOffset), "Order $order does not exist")
                     }
                 }
+                "clientSideOnly" -> {
+                    val value = keyValue.value ?: return
+                    val forgeVersion = runCatching {
+                        keyValue.findMcpModule()?.getSettings()?.platformVersion?.let(SemanticVersion::parse)
+                    }.getOrNull()
+                    val minVersion = ForgeConstants.CLIENT_ONLY_MANIFEST_VERSION
+                    if (forgeVersion != null && forgeVersion < minVersion) {
+                        holder.registerProblem(keyValue.key, "ClientSideOnly is only available since $minVersion")
+                    }
+                }
             }
         }
 

--- a/src/main/kotlin/toml/platform/forge/inspections/ModsTomlValidationInspection.kt
+++ b/src/main/kotlin/toml/platform/forge/inspections/ModsTomlValidationInspection.kt
@@ -113,7 +113,6 @@ class ModsTomlValidationInspection : LocalInspectionTool() {
                     }
                 }
                 "clientSideOnly" -> {
-                    val value = keyValue.value ?: return
                     val forgeVersion = runCatching {
                         keyValue.findMcpModule()?.getSettings()?.platformVersion?.let(SemanticVersion::parse)
                     }.getOrNull()

--- a/src/test/kotlin/platform/forge/ModsTomlCompletionTest.kt
+++ b/src/test/kotlin/platform/forge/ModsTomlCompletionTest.kt
@@ -53,6 +53,7 @@ class ModsTomlCompletionTest : BasePlatformTestCase() {
             "license",
             "showAsResourcePack",
             "issueTrackerURL",
+            "clientSideOnly",
         )
     }
 


### PR DESCRIPTION
Closes #2194

Adds:
- Code completion for `clientSideOnly` in mods.toml
    - <img width="367" alt="image" src="https://github.com/minecraft-dev/MinecraftDev/assets/3158390/e7e61f12-b397-4648-acbf-9e421ea5f16c">
- Validation for `clientSideOnly` values (can only be true/false)
    - <img width="299" alt="image" src="https://github.com/minecraft-dev/MinecraftDev/assets/3158390/61e78330-389e-4789-a93a-623aa3abcc6b">
- Version inspection and hover description
    - <img width="287" alt="image" src="https://github.com/minecraft-dev/MinecraftDev/assets/3158390/2d42f225-b195-490d-9041-7f2f3d2d1f39">
