### PR TITLE
Update mods.toml `displayTest` version check

### DIFF
--- a/src/main/kotlin/platform/forge/util/ForgeConstants.kt
+++ b/src/main/kotlin/platform/forge/util/ForgeConstants.kt
@@ -51,6 +51,6 @@ object ForgeConstants {
     // From https://github.com/MinecraftForge/MinecraftForge/blob/38a5400a8c878fe39cd389e6d4f68619d2738b88/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java#L45
     val MOD_ID_REGEX = "^[a-z][a-z0-9_-]{1,63}$".toRegex()
 
-    val DISPLAY_TEST_MANIFEST_VERSION = SemanticVersion.release(41, 0, 15)
+    val DISPLAY_TEST_MANIFEST_VERSION = SemanticVersion.release(40, 2, 14)
     val CLIENT_ONLY_MANIFEST_VERSION = SemanticVersion.release(49, 0, 6)
 }


### PR DESCRIPTION
Closes #2194.

Forge backported support for mods.toml displayTest to 1.18.2 in 40.2.14.