### PR TITLE
MixinExtras: Add handler signature support for expressions.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ dependencies {
     implementation(files(Jvm.current().toolsJar))
 
     // TODO: temporary waiting for MixinExtras expression library
-    implementation("com.github.LlamaLad7.MixinExtras:mixinextras-common:fe1e2b9")
+    implementation("com.github.LlamaLad7.MixinExtras:mixinextras-common:debfdc8")
     implementation("org.spongepowered:mixin:0.8.4")
     implementation("org.ow2.asm:asm-util:9.3")
 

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/InjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/InjectionPoint.kt
@@ -410,6 +410,7 @@ abstract class CollectVisitor<T : PsiElement>(protected val mode: Mode) {
         insn: AbstractInsnNode,
         element: T,
         qualifier: String? = null,
+        decorations: Map<String, Any?> = emptyMap(),
     ) {
         // apply shift.
         // being able to break out of the shift loops is important to prevent IDE freezes in case of large shift bys.
@@ -430,7 +431,14 @@ abstract class CollectVisitor<T : PsiElement>(protected val mode: Mode) {
             }
         }
 
-        val result = Result(nextIndex++, insn, shiftedInsn ?: return, element, qualifier)
+        val result = Result(
+            nextIndex++,
+            insn,
+            shiftedInsn ?: return,
+            element,
+            qualifier,
+            if (insn === shiftedInsn) decorations else emptyMap()
+        )
         var isFiltered = false
         for ((name, filter) in resultFilters) {
             if (!filter(result, method)) {
@@ -466,6 +474,7 @@ abstract class CollectVisitor<T : PsiElement>(protected val mode: Mode) {
         val insn: AbstractInsnNode,
         val target: T,
         val qualifier: String? = null,
+        val decorations: Map<String, Any?>
     )
 
     enum class Mode { MATCH_ALL, MATCH_FIRST, COMPLETION }

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyExpressionValueHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyExpressionValueHandler.kt
@@ -21,9 +21,12 @@
 package com.demonwav.mcdev.platform.mixin.handlers.mixinextras
 
 import com.demonwav.mcdev.platform.mixin.inspection.injector.ParameterGroup
+import com.demonwav.mcdev.platform.mixin.util.toPsiType
 import com.demonwav.mcdev.util.Parameter
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiType
+import com.llamalad7.mixinextras.utils.Decorations
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
@@ -31,7 +34,8 @@ import org.objectweb.asm.tree.MethodNode
 
 class ModifyExpressionValueHandler : MixinExtrasInjectorAnnotationHandler() {
     override val supportedInstructionTypes = listOf(
-        InstructionType.METHOD_CALL, InstructionType.FIELD_GET, InstructionType.INSTANTIATION, InstructionType.CONSTANT
+        InstructionType.METHOD_CALL, InstructionType.FIELD_GET, InstructionType.INSTANTIATION, InstructionType.CONSTANT,
+        InstructionType.SIMPLE_EXPRESSION
     )
 
     override fun extraTargetRestrictions(insn: AbstractInsnNode): Boolean {
@@ -43,9 +47,23 @@ class ModifyExpressionValueHandler : MixinExtrasInjectorAnnotationHandler() {
         annotation: PsiAnnotation,
         targetClass: ClassNode,
         targetMethod: MethodNode,
-        insn: AbstractInsnNode
+        target: TargetInsn
     ): Pair<ParameterGroup, PsiType>? {
-        val psiType = getPsiReturnType(insn, annotation) ?: return null
+        val psiType = getReturnType(target, annotation) ?: return null
         return ParameterGroup(listOf(Parameter("original", psiType))) to psiType
+    }
+
+    private fun getReturnType(
+        target: TargetInsn,
+        annotation: PsiAnnotation
+    ): PsiType? {
+        val psiReturnType = getPsiReturnType(target.insn, annotation)
+        val rawReturnType = getInsnReturnType(target.insn)
+        val exprType = target.getDecoration<Type>(Decorations.SIMPLE_EXPRESSION_TYPE)
+        if (exprType != null && rawReturnType != exprType) {
+            // The expression knows more than the standard logic does.
+            return exprType.toPsiType(JavaPsiFacade.getElementFactory(annotation.project))
+        }
+        return psiReturnType
     }
 }

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyReceiverHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyReceiverHandler.kt
@@ -44,9 +44,9 @@ class ModifyReceiverHandler : MixinExtrasInjectorAnnotationHandler() {
         annotation: PsiAnnotation,
         targetClass: ClassNode,
         targetMethod: MethodNode,
-        insn: AbstractInsnNode
+        target: TargetInsn
     ): Pair<ParameterGroup, PsiType>? {
-        val params = getPsiParameters(insn, targetClass, annotation) ?: return null
+        val params = getPsiParameters(target.insn, targetClass, annotation) ?: return null
         return ParameterGroup(params) to params[0].type
     }
 }

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyReturnValueHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyReturnValueHandler.kt
@@ -25,7 +25,6 @@ import com.demonwav.mcdev.platform.mixin.util.getGenericReturnType
 import com.demonwav.mcdev.util.Parameter
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiType
-import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodNode
 
@@ -36,8 +35,8 @@ class ModifyReturnValueHandler : MixinExtrasInjectorAnnotationHandler() {
         annotation: PsiAnnotation,
         targetClass: ClassNode,
         targetMethod: MethodNode,
-        insn: AbstractInsnNode
-    ): Pair<ParameterGroup, PsiType>? {
+        target: TargetInsn
+    ): Pair<ParameterGroup, PsiType> {
         val returnType = targetMethod.getGenericReturnType(targetClass, annotation.project)
         return ParameterGroup(listOf(Parameter("original", returnType))) to returnType
     }

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/TargetInsn.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/TargetInsn.kt
@@ -1,0 +1,30 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2024 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.platform.mixin.handlers.mixinextras
+
+import org.objectweb.asm.tree.AbstractInsnNode
+
+class TargetInsn(val insn: AbstractInsnNode, private val decorations: Map<String, Any?>) {
+    fun hasDecoration(key: String) = key in decorations
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T> getDecoration(key: String): T? = decorations[key] as T
+}

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapOperationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapOperationHandler.kt
@@ -22,20 +22,22 @@ package com.demonwav.mcdev.platform.mixin.handlers.mixinextras
 
 import com.demonwav.mcdev.platform.mixin.inspection.injector.ParameterGroup
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.MixinExtras.OPERATION
+import com.demonwav.mcdev.platform.mixin.util.toPsiType
 import com.demonwav.mcdev.util.Parameter
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
-import org.objectweb.asm.tree.AbstractInsnNode
+import com.llamalad7.mixinextras.utils.Decorations
+import org.objectweb.asm.Type
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodNode
 
 class WrapOperationHandler : MixinExtrasInjectorAnnotationHandler() {
     override val supportedInstructionTypes = listOf(
         InstructionType.METHOD_CALL, InstructionType.FIELD_GET, InstructionType.FIELD_SET, InstructionType.INSTANCEOF,
-        InstructionType.INSTANTIATION
+        InstructionType.INSTANTIATION, InstructionType.SIMPLE_OPERATION
     )
 
     override fun getAtKey(annotation: PsiAnnotation): String {
@@ -46,14 +48,33 @@ class WrapOperationHandler : MixinExtrasInjectorAnnotationHandler() {
         annotation: PsiAnnotation,
         targetClass: ClassNode,
         targetMethod: MethodNode,
-        insn: AbstractInsnNode
+        target: TargetInsn
     ): Pair<ParameterGroup, PsiType>? {
-        val params = getPsiParameters(insn, targetClass, annotation) ?: return null
-        val returnType = getPsiReturnType(insn, annotation) ?: return null
+        val params = getParameterTypes(target, targetClass, annotation) ?: return null
+        val returnType = getReturnType(target, annotation) ?: return null
         val operationType = getOperationType(annotation, returnType) ?: return null
         return ParameterGroup(
             params + Parameter("original", operationType)
         ) to returnType
+    }
+
+    private fun getParameterTypes(
+        target: TargetInsn,
+        targetClass: ClassNode,
+        annotation: PsiAnnotation
+    ): List<Parameter>? {
+        getPsiParameters(target.insn, targetClass, annotation)?.let { return it }
+        val args = target.getDecoration<Array<Type>>(Decorations.SIMPLE_OPERATION_ARGS) ?: return null
+        return args.toList().toParameters(annotation)
+    }
+
+    private fun getReturnType(
+        target: TargetInsn,
+        annotation: PsiAnnotation
+    ): PsiType? {
+        getPsiReturnType(target.insn, annotation)?.let { return it }
+        val type = target.getDecoration<Type>(Decorations.SIMPLE_OPERATION_RETURN_TYPE) ?: return null
+        return type.toPsiType(JavaPsiFacade.getElementFactory(annotation.project))
     }
 
     private fun getOperationType(context: PsiElement, type: PsiType): PsiType? {

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapWithConditionHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapWithConditionHandler.kt
@@ -42,9 +42,9 @@ class WrapWithConditionHandler : MixinExtrasInjectorAnnotationHandler() {
         annotation: PsiAnnotation,
         targetClass: ClassNode,
         targetMethod: MethodNode,
-        insn: AbstractInsnNode
+        target: TargetInsn
     ): Pair<ParameterGroup, PsiType>? {
-        val params = getPsiParameters(insn, targetClass, annotation) ?: return null
+        val params = getPsiParameters(target.insn, targetClass, annotation) ?: return null
         return ParameterGroup(params) to PsiTypes.booleanType()
     }
 }


### PR DESCRIPTION
There are still 2 things to address, but you'd probably be better placed to implement them than me.
1. It doesn't handle `int-like` types. Ideally the user would be presented with a dropdown of the suitable types so they can choose. All int-like types within the handler should match (at least with the current possible targets). If that is too much to ask then it should probably just treat them as `int` types, but I do worry the users would get confused when they expected e.g. a char and have to change it themselves.
2. Not a direct result of this PR but the name suggestion code suggests duplicate names for parameters of the same type, which causes issues. This is noticeable e.g. when wrapping a comparison.

(I don't want this to target dev but I don't seem to have a choice. It can be manually merged. Review the latest commit only.)