### PR TITLE
Don't check `@Final` for fields with initializers

### DIFF
--- a/src/main/kotlin/platform/mixin/inspection/shadow/ShadowModifiersInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/shadow/ShadowModifiersInspection.kt
@@ -103,8 +103,10 @@ class ShadowModifiersInspection : MixinInspection() {
             // TODO: Would it make sense to apply the @Final check to methods?
             if (member !is PsiField) {
                 return
-            } else if (member.hasInitializer()) {
-                // @Final annotation doesn't apply to members that are initialized in the mixin class
+            }
+
+            // @Final annotation doesn't apply to members that are initialized in the mixin class
+            if (member.hasInitializer()) {
                 return
             }
 

--- a/src/main/kotlin/platform/mixin/inspection/shadow/ShadowModifiersInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/shadow/ShadowModifiersInspection.kt
@@ -103,6 +103,9 @@ class ShadowModifiersInspection : MixinInspection() {
             // TODO: Would it make sense to apply the @Final check to methods?
             if (member !is PsiField) {
                 return
+            } else if (member.hasInitializer()) {
+                // @Final annotation doesn't apply to members that are initialized in the mixin class
+                return
             }
 
             // Check @Final


### PR DESCRIPTION
Mixin `@Shadow` fields only require `@Final` when they don't have an initializer. When they do have an initializer, Mixin will throw a warning saying to just use the `final` modifier. This fixes the inspection to no longer apply to fields with an initializer.