### PR TITLE
Fix/expressions int like types

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyExpressionValueHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/ModifyExpressionValueHandler.kt
@@ -20,6 +20,7 @@
 
 package com.demonwav.mcdev.platform.mixin.handlers.mixinextras
 
+import com.demonwav.mcdev.platform.mixin.inspection.injector.MethodSignature
 import com.demonwav.mcdev.platform.mixin.inspection.injector.ParameterGroup
 import com.demonwav.mcdev.platform.mixin.util.toPsiType
 import com.demonwav.mcdev.util.Parameter
@@ -27,6 +28,7 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiType
 import com.llamalad7.mixinextras.utils.Decorations
+import com.llamalad7.mixinextras.utils.TypeUtils
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
@@ -51,6 +53,14 @@ class ModifyExpressionValueHandler : MixinExtrasInjectorAnnotationHandler() {
     ): Pair<ParameterGroup, PsiType>? {
         val psiType = getReturnType(target, annotation) ?: return null
         return ParameterGroup(listOf(Parameter("original", psiType))) to psiType
+    }
+
+    override fun intLikeTypePositions(target: TargetInsn): List<MethodSignature.TypePosition> {
+        val expressionType = target.getDecoration<Type>(Decorations.SIMPLE_EXPRESSION_TYPE)
+        if (expressionType == TypeUtils.INTLIKE_TYPE) {
+            return listOf(MethodSignature.TypePosition.Return, MethodSignature.TypePosition.Param(0))
+        }
+        return emptyList()
     }
 
     private fun getReturnType(

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapOperationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/WrapOperationHandler.kt
@@ -20,6 +20,7 @@
 
 package com.demonwav.mcdev.platform.mixin.handlers.mixinextras
 
+import com.demonwav.mcdev.platform.mixin.inspection.injector.MethodSignature
 import com.demonwav.mcdev.platform.mixin.inspection.injector.ParameterGroup
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.MixinExtras.OPERATION
 import com.demonwav.mcdev.platform.mixin.util.toPsiType
@@ -30,6 +31,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
 import com.llamalad7.mixinextras.utils.Decorations
+import com.llamalad7.mixinextras.utils.TypeUtils
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodNode
@@ -56,6 +58,17 @@ class WrapOperationHandler : MixinExtrasInjectorAnnotationHandler() {
         return ParameterGroup(
             params + Parameter("original", operationType)
         ) to returnType
+    }
+
+    override fun intLikeTypePositions(target: TargetInsn) = buildList {
+        if (target.getDecoration<Type>(Decorations.SIMPLE_OPERATION_RETURN_TYPE) == TypeUtils.INTLIKE_TYPE) {
+            add(MethodSignature.TypePosition.Return)
+        }
+        target.getDecoration<Array<Type>>(Decorations.SIMPLE_OPERATION_ARGS)?.forEachIndexed { i, it ->
+            if (it == TypeUtils.INTLIKE_TYPE) {
+                add(MethodSignature.TypePosition.Param(i))
+            }
+        }
     }
 
     private fun getParameterTypes(

--- a/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
@@ -33,20 +33,33 @@ import com.demonwav.mcdev.platform.mixin.util.isConstructor
 import com.demonwav.mcdev.platform.mixin.util.isMixinExtrasSugar
 import com.demonwav.mcdev.util.Parameter
 import com.demonwav.mcdev.util.fullQualifiedName
+import com.demonwav.mcdev.util.invokeLater
 import com.demonwav.mcdev.util.synchronize
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
 import com.intellij.codeInsight.intention.QuickFixFactory
-import com.intellij.codeInspection.LocalQuickFix
-import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.codeInsight.template.Expression
+import com.intellij.codeInsight.template.ExpressionContext
+import com.intellij.codeInsight.template.Template
+import com.intellij.codeInsight.template.TemplateBuilderImpl
+import com.intellij.codeInsight.template.TemplateManager
+import com.intellij.codeInsight.template.TextResult
+import com.intellij.codeInsight.template.impl.VariableNode
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.JavaElementVisitor
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiNameHelper
@@ -57,6 +70,8 @@ import com.intellij.psi.codeStyle.JavaCodeStyleManager
 import com.intellij.psi.codeStyle.VariableKind
 import com.intellij.psi.util.PsiUtil
 import com.intellij.psi.util.TypeConversionUtil
+import com.intellij.psi.util.parentOfType
+import com.intellij.refactoring.suggested.startOffset
 import org.objectweb.asm.Opcodes
 
 class InvalidInjectorMethodSignatureInspection : MixinInspection() {
@@ -166,7 +181,7 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
                         }
 
                         if (!isValid) {
-                            val (expectedParameters, expectedReturnType) = possibleSignatures[0]
+                            val (expectedParameters, expectedReturnType, intLikeTypePositions) = possibleSignatures[0]
 
                             val paramsCheck = checkParameters(parameters, expectedParameters, handler.allowCoerce)
                             val isWarning = paramsCheck == CheckResult.WARNING
@@ -180,8 +195,10 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
                                 val description =
                                     "Method signature does not match expected signature for $annotationName"
                                 val quickFix = SignatureQuickFix(
+                                    method,
                                     expectedParameters.takeUnless { paramsCheck == CheckResult.OK },
                                     expectedReturnType.takeUnless { returnTypeOk },
+                                    intLikeTypePositions
                                 )
                                 val highlightType =
                                     if (isError)
@@ -276,20 +293,33 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
     }
 
     private class SignatureQuickFix(
+        method: PsiMethod,
         @SafeFieldForPreview
         private val expectedParams: List<ParameterGroup>?,
         @SafeFieldForPreview
         private val expectedReturnType: PsiType?,
-    ) : LocalQuickFix {
+        private val intLikeTypePositions: List<MethodSignature.TypePosition>
+    ) : LocalQuickFixAndIntentionActionOnPsiElement(method) {
 
         private val fixName = "Fix method signature"
 
         override fun getFamilyName() = fixName
 
-        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-            val method = descriptor.psiElement as PsiMethod
+        override fun getText() = familyName
+
+        override fun startInWriteAction() = false
+
+        override fun invoke(
+            project: Project,
+            file: PsiFile,
+            editor: Editor?,
+            startElement: PsiElement,
+            endElement: PsiElement,
+        ) {
+            val method = startElement as PsiMethod
             fixParameters(project, method.parameterList)
             fixReturnType(method)
+            fixIntLikeTypes(method, editor ?: return)
         }
 
         private fun fixParameters(project: Project, parameters: PsiParameterList) {
@@ -340,6 +370,67 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
                 .applyFix()
         }
 
-        override fun startInWriteAction() = false
+        private fun fixIntLikeTypes(method: PsiMethod, editor: Editor) {
+            if (intLikeTypePositions.isEmpty()) {
+                return
+            }
+            invokeLater {
+                WriteCommandAction.runWriteCommandAction(
+                    method.project,
+                    "Choose Int-Like Type",
+                    null,
+                    {
+                        val template = makeIntLikeTypeTemplate(method, intLikeTypePositions)
+                        if (template != null) {
+                            editor.caretModel.moveToOffset(method.startOffset)
+                            TemplateManager.getInstance(method.project)
+                                .startTemplate(editor, template)
+                        }
+                    },
+                    method.parentOfType<PsiFile>()!!
+                )
+            }
+        }
+
+        private fun makeIntLikeTypeTemplate(
+            method: PsiMethod,
+            positions: List<MethodSignature.TypePosition>
+        ): Template? {
+            val builder = TemplateBuilderImpl(method)
+            builder.replaceElement(
+                positions.first().getElement(method) ?: return null,
+                "intliketype",
+                ChooseIntLikeTypeExpression(),
+                true
+            )
+            for (pos in positions.drop(1)) {
+                builder.replaceElement(
+                    pos.getElement(method) ?: return null,
+                    VariableNode("intliketype", null),
+                    false
+                )
+            }
+            return builder.buildInlineTemplate()
+        }
+    }
+}
+
+private class ChooseIntLikeTypeExpression : Expression() {
+    private val lookupItems: Array<LookupElement> = intLikeTypes.map(LookupElementBuilder::create).toTypedArray()
+
+    override fun calculateLookupItems(context: ExpressionContext) = if (lookupItems.size > 1) lookupItems else null
+
+    override fun calculateQuickResult(context: ExpressionContext) = calculateResult(context)
+
+    override fun calculateResult(context: ExpressionContext) = TextResult("int")
+
+    private companion object {
+        private val intLikeTypes = listOf(
+            "int",
+            "char",
+            "boolean",
+            "byte",
+            "short"
+        )
     }
 }

--- a/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
@@ -35,6 +35,7 @@ import com.demonwav.mcdev.util.Parameter
 import com.demonwav.mcdev.util.fullQualifiedName
 import com.demonwav.mcdev.util.invokeLater
 import com.demonwav.mcdev.util.synchronize
+import com.intellij.codeInsight.FileModificationService
 import com.intellij.codeInsight.intention.FileModifier.SafeFieldForPreview
 import com.intellij.codeInsight.intention.QuickFixFactory
 import com.intellij.codeInsight.lookup.LookupElement
@@ -316,6 +317,9 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
             startElement: PsiElement,
             endElement: PsiElement,
         ) {
+            if (!FileModificationService.getInstance().preparePsiElementForWrite(startElement)) {
+                return
+            }
             val method = startElement as PsiMethod
             fixParameters(project, method.parameterList)
             fixReturnType(method)

--- a/src/main/kotlin/platform/mixin/inspection/injector/MethodSignature.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/MethodSignature.kt
@@ -20,6 +20,24 @@
 
 package com.demonwav.mcdev.platform.mixin.inspection.injector
 
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypeElement
 
-data class MethodSignature(val parameters: List<ParameterGroup>, val returnType: PsiType)
+data class MethodSignature(
+    val parameters: List<ParameterGroup>,
+    val returnType: PsiType,
+    val intLikeTypes: List<TypePosition> = emptyList()
+) {
+    sealed interface TypePosition {
+        fun getElement(method: PsiMethod): PsiTypeElement?
+
+        data object Return : TypePosition {
+            override fun getElement(method: PsiMethod) = method.returnTypeElement
+        }
+
+        data class Param(val index: Int) : TypePosition {
+            override fun getElement(method: PsiMethod) = method.parameterList.parameters[index].typeElement
+        }
+    }
+}

--- a/src/main/kotlin/platform/mixin/util/AsmUtil.kt
+++ b/src/main/kotlin/platform/mixin/util/AsmUtil.kt
@@ -67,11 +67,13 @@ import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiParameterList
 import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypes
 import com.intellij.psi.impl.compiled.ClsElementImpl
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiUtil
 import com.intellij.refactoring.util.LambdaRefactoringUtil
 import com.intellij.util.CommonJavaRefactoringUtil
+import com.llamalad7.mixinextras.utils.TypeUtils
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import org.objectweb.asm.ClassReader
@@ -129,6 +131,9 @@ private fun hasModifier(access: Int, @PsiModifier.ModifierConstant modifier: Str
 }
 
 fun Type.toPsiType(elementFactory: PsiElementFactory, context: PsiElement? = null): PsiType {
+    if (this == TypeUtils.INTLIKE_TYPE) {
+        return PsiTypes.intType()
+    }
     val javaClassName = className.replace("(\\$)(\\D)".toRegex()) { "." + it.groupValues[2] }
     return elementFactory.createTypeFromText(javaClassName, context)
 }

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureFixTest.kt
@@ -33,7 +33,7 @@ class InvalidInjectorMethodSignatureFixTest : BaseMixinTest() {
 
     private fun doTest(testName: String) {
         fixture.enableInspections(InvalidInjectorMethodSignatureInspection::class)
-        testInspectionFix(fixture, "invalidInjectorMethodSignature/$testName", "Fix method parameters")
+        testInspectionFix(fixture, "invalidInjectorMethodSignature/$testName", "Fix method signature")
     }
 
     @Test

--- a/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureInspectionTest.kt
+++ b/src/test/kotlin/platform/mixin/InvalidInjectorMethodSignatureInspectionTest.kt
@@ -98,7 +98,7 @@ class InvalidInjectorMethodSignatureInspectionTest : BaseMixinTest() {
                 }
 
                 @Inject(method = "<init>(Lcom/demonwav/mcdev/mixintestdata/invalidInjectorMethodSignatureInspection/MixedInOuter;Ljava/lang/String;)V", at = @At("RETURN"))
-                private void injectCtor<error descr="Method parameters do not match expected parameters for Inject">(String string, CallbackInfo ci)</error> {
+                private <error descr="Method signature does not match expected signature for Inject">void injectCtor(String string, CallbackInfo ci)</error> {
                 }
             }
             """,
@@ -122,7 +122,7 @@ class InvalidInjectorMethodSignatureInspectionTest : BaseMixinTest() {
             public class TestMixin {
 
                 @Inject(method = "<init>()V", at = @At("RETURN"))
-                private void injectCtorWrong<error descr="Method parameters do not match expected parameters for Inject">(MixedInOuter outer, CallbackInfo ci)</error> {
+                private <error descr="Method signature does not match expected signature for Inject">void injectCtorWrong(MixedInOuter outer, CallbackInfo ci)</error> {
                 }
 
                 @Inject(method = "<init>", at = @At("RETURN"))
@@ -130,7 +130,7 @@ class InvalidInjectorMethodSignatureInspectionTest : BaseMixinTest() {
                 }
 
                 @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))
-                private void injectCtor<error descr="Method parameters do not match expected parameters for Inject">(MixedInOuter outer, String string, CallbackInfo ci)</error> {
+                private <error descr="Method signature does not match expected signature for Inject">void injectCtor(MixedInOuter outer, String string, CallbackInfo ci)</error> {
                 }
 
                 @Inject(method = "<init>(Ljava/lang/String;)V", at = @At("RETURN"))


### PR DESCRIPTION
Also combines return type + param inspections for handler methods.
Best consumed in individual commits.
Some of the code is slightly messy so feel free to clean up.