### PR TITLE
Allow dynamic selectors to choose the class to perform member lookups in

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
@@ -25,7 +25,6 @@ import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.CollectVisitor
 import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.InsnResolutionInfo
 import com.demonwav.mcdev.platform.mixin.inspection.injector.MethodSignature
 import com.demonwav.mcdev.platform.mixin.reference.DescSelectorParser
-import com.demonwav.mcdev.platform.mixin.reference.DynamicMixinSelector
 import com.demonwav.mcdev.platform.mixin.reference.isMiscDynamicSelector
 import com.demonwav.mcdev.platform.mixin.reference.parseMixinSelector
 import com.demonwav.mcdev.platform.mixin.util.ClassAndMethodNode
@@ -62,7 +61,7 @@ abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
             desc.mapNotNull { DescSelectorParser.descSelectorFromAnnotation(it) }
 
         val targetClassMethods = selectors.associateWith { selector ->
-            val actualTarget = DynamicMixinSelector.apply(selector, targetClass)
+            val actualTarget = selector.getCustomOwner(targetClass)
             (actualTarget to actualTarget.methods)
         }
 

--- a/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
@@ -25,6 +25,7 @@ import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.CollectVisitor
 import com.demonwav.mcdev.platform.mixin.handlers.injectionPoint.InsnResolutionInfo
 import com.demonwav.mcdev.platform.mixin.inspection.injector.MethodSignature
 import com.demonwav.mcdev.platform.mixin.reference.DescSelectorParser
+import com.demonwav.mcdev.platform.mixin.reference.DynamicMixinSelector
 import com.demonwav.mcdev.platform.mixin.reference.isMiscDynamicSelector
 import com.demonwav.mcdev.platform.mixin.reference.parseMixinSelector
 import com.demonwav.mcdev.platform.mixin.util.ClassAndMethodNode
@@ -54,19 +55,25 @@ import org.objectweb.asm.tree.MethodNode
 
 abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
     override fun resolveTarget(annotation: PsiAnnotation, targetClass: ClassNode): List<MixinTargetMember> {
-        val targetClassMethods = targetClass.methods ?: return emptyList()
-
         val methodAttr = annotation.findAttributeValue("method")
         val method = methodAttr?.computeStringArray() ?: emptyList()
         val desc = annotation.findAttributeValue("desc")?.findAnnotations() ?: emptyList()
         val selectors = method.mapNotNull { parseMixinSelector(it, methodAttr!!) } +
             desc.mapNotNull { DescSelectorParser.descSelectorFromAnnotation(it) }
 
-        return targetClassMethods.mapNotNull { targetMethod ->
-            if (selectors.any { it.matchMethod(targetMethod, targetClass) }) {
-                MethodTargetMember(targetClass, targetMethod)
-            } else {
-                null
+        val targetClassMethods = selectors.associateWith { selector ->
+            val actualTarget = DynamicMixinSelector.apply(selector, targetClass)
+            (actualTarget to actualTarget.methods)
+        }
+
+        return targetClassMethods.mapNotNull { (selector, pair) ->
+            val (clazz, methods) = pair
+            methods.firstNotNullOfOrNull { method ->
+                if (selector.matchMethod(method, clazz)) {
+                    MethodTargetMember(clazz, method)
+                } else {
+                    null
+                }
             }
         }
     }
@@ -99,7 +106,7 @@ abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
     override fun resolveForNavigation(annotation: PsiAnnotation, targetClass: ClassNode): List<PsiElement> {
         return resolveTarget(annotation, targetClass).flatMap { targetMember ->
             val targetMethod = targetMember as? MethodTargetMember ?: return@flatMap emptyList()
-            resolveForNavigation(annotation, targetClass, targetMethod.classAndMethod.method)
+            resolveForNavigation(annotation, targetMethod.classAndMethod.clazz, targetMethod.classAndMethod.method)
         }
     }
 

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/AtResolver.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/AtResolver.kt
@@ -20,7 +20,6 @@
 
 package com.demonwav.mcdev.platform.mixin.handlers.injectionPoint
 
-import com.demonwav.mcdev.platform.mixin.reference.DynamicMixinSelector
 import com.demonwav.mcdev.platform.mixin.reference.MixinSelector
 import com.demonwav.mcdev.platform.mixin.reference.isMiscDynamicSelector
 import com.demonwav.mcdev.platform.mixin.reference.parseMixinSelector
@@ -240,7 +239,7 @@ class AtResolver(
     }
 
     private fun getTargetClass(selector: MixinSelector?): ClassNode {
-        return DynamicMixinSelector.apply(selector, targetClass)
+        return selector?.getCustomOwner(targetClass) ?: targetClass
     }
 }
 

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/AtResolver.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/AtResolver.kt
@@ -20,6 +20,8 @@
 
 package com.demonwav.mcdev.platform.mixin.handlers.injectionPoint
 
+import com.demonwav.mcdev.platform.mixin.reference.DynamicMixinSelector
+import com.demonwav.mcdev.platform.mixin.reference.MixinSelector
 import com.demonwav.mcdev.platform.mixin.reference.isMiscDynamicSelector
 import com.demonwav.mcdev.platform.mixin.reference.parseMixinSelector
 import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
@@ -152,7 +154,7 @@ class AtResolver(
         val collectVisitor = injectionPoint.createCollectVisitor(
             at,
             target,
-            targetClass,
+            getTargetClass(target),
             CollectVisitor.Mode.MATCH_FIRST,
         )
         if (collectVisitor == null) {
@@ -181,7 +183,7 @@ class AtResolver(
         val targetAttr = at.findAttributeValue("target")
         val target = targetAttr?.let { parseMixinSelector(it) }
 
-        val collectVisitor = injectionPoint.createCollectVisitor(at, target, targetClass, mode)
+        val collectVisitor = injectionPoint.createCollectVisitor(at, target, getTargetClass(target), mode)
             ?: return InsnResolutionInfo.Failure()
         collectVisitor.visit(targetMethod)
         val result = collectVisitor.result
@@ -201,7 +203,7 @@ class AtResolver(
 
         // Then attempt to find the corresponding source elements using the navigation visitor
         val targetElement = targetMethod.findSourceElement(
-            targetClass,
+            getTargetClass(target),
             at.project,
             GlobalSearchScope.allScope(at.project),
             canDecompile = true,
@@ -223,15 +225,22 @@ class AtResolver(
 
         // Collect all possible targets
         fun <T : PsiElement> doCollectVariants(injectionPoint: InjectionPoint<T>): List<Any> {
-            val visitor = injectionPoint.createCollectVisitor(at, target, targetClass, CollectVisitor.Mode.COMPLETION)
+            val visitor = injectionPoint.createCollectVisitor(
+                at, target, getTargetClass(target),
+                CollectVisitor.Mode.COMPLETION
+            )
                 ?: return emptyList()
             visitor.visit(targetMethod)
             return visitor.result
                 .mapNotNull { result ->
-                    injectionPoint.createLookup(targetClass, result)?.let { completionHandler(it) }
+                    injectionPoint.createLookup(getTargetClass(target), result)?.let { completionHandler(it) }
                 }
         }
         return doCollectVariants(injectionPoint)
+    }
+
+    private fun getTargetClass(selector: MixinSelector?): ClassNode {
+        return DynamicMixinSelector.apply(selector, targetClass)
     }
 }
 

--- a/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
@@ -84,7 +84,7 @@ abstract class AbstractMethodReference : PolyReferenceResolver(), MixinReference
         val targetMethodInfo = parseSelector(stringValue, context) ?: return false
         val targets = getTargets(context) ?: return false
         return !targets.asSequence().flatMap {
-            DynamicMixinSelector.apply(targetMethodInfo, it).findMethods(targetMethodInfo)
+            targetMethodInfo.getCustomOwner(it).findMethods(targetMethodInfo)
         }.any()
     }
 
@@ -128,7 +128,7 @@ abstract class AbstractMethodReference : PolyReferenceResolver(), MixinReference
     ): Sequence<ClassAndMethodNode> {
         return targets.asSequence()
             .flatMap { target ->
-                val actualTarget = DynamicMixinSelector.apply(selector, target)
+                val actualTarget = selector.getCustomOwner(target)
                 actualTarget.findMethods(selector).map { ClassAndMethodNode(actualTarget, it) }
             }
     }

--- a/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
@@ -83,7 +83,9 @@ abstract class AbstractMethodReference : PolyReferenceResolver(), MixinReference
         val stringValue = context.constantStringValue ?: return false
         val targetMethodInfo = parseSelector(stringValue, context) ?: return false
         val targets = getTargets(context) ?: return false
-        return !targets.asSequence().flatMap { it.findMethods(targetMethodInfo) }.any()
+        return !targets.asSequence().flatMap {
+            DynamicMixinSelector.apply(targetMethodInfo, it).findMethods(targetMethodInfo)
+        }.any()
     }
 
     fun getReferenceIfAmbiguous(context: PsiElement): MemberReference? {
@@ -125,7 +127,10 @@ abstract class AbstractMethodReference : PolyReferenceResolver(), MixinReference
         selector: MixinSelector,
     ): Sequence<ClassAndMethodNode> {
         return targets.asSequence()
-            .flatMap { target -> target.findMethods(selector).map { ClassAndMethodNode(target, it) } }
+            .flatMap { target ->
+                val actualTarget = DynamicMixinSelector.apply(selector, target)
+                actualTarget.findMethods(selector).map { ClassAndMethodNode(actualTarget, it) }
+            }
     }
 
     fun resolveIfUnique(context: PsiElement): ClassAndMethodNode? {

--- a/src/main/kotlin/platform/mixin/util/MixinConstants.kt
+++ b/src/main/kotlin/platform/mixin/util/MixinConstants.kt
@@ -38,6 +38,7 @@ object MixinConstants {
         const val CONSTANT_CONDITION = "org.spongepowered.asm.mixin.injection.Constant.Condition"
         const val INJECTION_POINT = "org.spongepowered.asm.mixin.injection.InjectionPoint"
         const val SELECTOR = "org.spongepowered.asm.mixin.injection.InjectionPoint.Selector"
+        const val TARGET_SELECTOR = "org.spongepowered.asm.mixin.injection.selectors.TargetSelector"
         const val MIXIN_AGENT = "org.spongepowered.tools.agent.MixinAgent"
         const val MIXIN_CONFIG = "org.spongepowered.asm.mixin.transformer.MixinConfig"
         const val MIXIN_PLUGIN = "org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin"


### PR DESCRIPTION
## Motivation

MixinSquared's [`@TargetHandler`](https://github.com/Bawnorton/MixinSquared/wiki#target-handler) is a dynamic selector which targets merged handlers, the accepted references are the name of the mixin and the original name of the handler. The method targeting is the same as `@At.method` but the members are declared in the mixin class specified by the `mixin` attribute, thus, when looking up members for a `@TargetHandler` selector, the class specified in `mixin` would be the one to lookup. Mcdev's member lookups work off the target class specified in the `@Mixin` annotation, thus, this change is needed to allow the lookup to occur in a different class.

This pr also fixes namespace lookup as you do not have to declare the namespace for a dynamic selector in the annotation and can instead declare it at registration.

See #2287 