### PR TITLE
Move "Method must not be static" error message to static keyword

### DIFF
--- a/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/injector/InvalidInjectorMethodSignatureInspection.kt
@@ -32,6 +32,7 @@ import com.demonwav.mcdev.platform.mixin.util.isAssignable
 import com.demonwav.mcdev.platform.mixin.util.isConstructor
 import com.demonwav.mcdev.platform.mixin.util.isMixinExtrasSugar
 import com.demonwav.mcdev.util.Parameter
+import com.demonwav.mcdev.util.findKeyword
 import com.demonwav.mcdev.util.fullQualifiedName
 import com.demonwav.mcdev.util.invokeLater
 import com.demonwav.mcdev.util.synchronize
@@ -133,7 +134,7 @@ class InvalidInjectorMethodSignatureInspection : MixinInspection() {
                         } else if (!shouldBeStatic && modifiers.hasModifierProperty(PsiModifier.STATIC)) {
                             reportedStatic = true
                             holder.registerProblem(
-                                identifier,
+                                modifiers.findKeyword(PsiModifier.STATIC) ?: identifier,
                                 "Method must not be static",
                                 QuickFixFactory.getInstance().createModifierListFix(
                                     modifiers,


### PR DESCRIPTION
Made "Method must not be static" error be on the static keyword instead of the method name
This is a pull request for issue https://github.com/minecraft-dev/MinecraftDev/issues/2353