### PR TITLE
feat: add bedrock nbt and leveldat support

### DIFF
--- a/src/main/kotlin/nbt/editor/NbtFormat.kt
+++ b/src/main/kotlin/nbt/editor/NbtFormat.kt
@@ -22,10 +22,11 @@ package com.demonwav.mcdev.nbt.editor
 
 import com.demonwav.mcdev.asset.MCDevBundle
 
-enum class CompressionSelection(private val selectionNameFunc: () -> String) {
-    GZIP({ MCDevBundle("nbt.compression.gzip") }),
-    UNCOMPRESSED({ MCDevBundle("nbt.compression.uncompressed") }),
-    ;
+enum class NbtFormat(private val selectionNameFunc: () -> String) {
+    LITTLE_ENDIAN_NETWORK({ MCDevBundle("nbt.format.little_network") }),
+    BIG_ENDIAN_GZIP({ MCDevBundle("nbt.format.big_gzip") }),
+    LITTLE_ENDIAN({ MCDevBundle("nbt.format.little") }),
+    BIG_ENDIAN({ MCDevBundle("nbt.format.big") }), ;
 
     override fun toString(): String = selectionNameFunc()
 }

--- a/src/main/kotlin/nbt/editor/NbtToolbar.kt
+++ b/src/main/kotlin/nbt/editor/NbtToolbar.kt
@@ -30,19 +30,17 @@ import com.intellij.ui.dsl.builder.panel
 
 class NbtToolbar(nbtFile: NbtVirtualFile) {
 
-    private var compressionSelection: CompressionSelection? =
-        if (nbtFile.isCompressed) CompressionSelection.GZIP else CompressionSelection.UNCOMPRESSED
+    private var nbtFormat: NbtFormat? = nbtFile.nbtFormat
 
-    val selection: CompressionSelection
-        get() = compressionSelection!!
+    val selection: NbtFormat get() = nbtFormat!!
 
     lateinit var panel: DialogPanel
 
     init {
         panel = panel {
-            row(MCDevBundle("nbt.compression.file_type.label")) {
-                comboBox(EnumComboBoxModel(CompressionSelection::class.java))
-                    .bindItem(::compressionSelection)
+            row(MCDevBundle("nbt.format.label")) {
+                comboBox(EnumComboBoxModel(NbtFormat::class.java))
+                    .bindItem(::nbtFormat)
                     .enabled(nbtFile.isWritable && nbtFile.parseSuccessful)
                 button(MCDevBundle("nbt.compression.save.button")) {
                     panel.apply()

--- a/src/main/kotlin/nbt/util/LittleEndianDataInputStream.kt
+++ b/src/main/kotlin/nbt/util/LittleEndianDataInputStream.kt
@@ -1,0 +1,87 @@
+package com.demonwav.mcdev.nbt.util
+
+import java.io.*
+import java.nio.charset.StandardCharsets
+
+open class LittleEndianDataInputStream(stream: InputStream) : FilterInputStream(DataInputStream(stream)), DataInput {
+
+    protected val dataStream = DataInputStream(stream)
+
+    @Throws(IOException::class)
+    override fun readFully(bytes: ByteArray) {
+        dataStream.readFully(bytes)
+    }
+
+    @Throws(IOException::class)
+    override fun readFully(bytes: ByteArray, offset: Int, length: Int) {
+        dataStream.readFully(bytes, offset, length)
+    }
+
+    @Throws(IOException::class)
+    override fun skipBytes(amount: Int): Int {
+        return dataStream.skipBytes(amount)
+    }
+
+    @Throws(IOException::class)
+    override fun readBoolean(): Boolean {
+        return dataStream.readBoolean()
+    }
+
+    @Throws(IOException::class)
+    override fun readByte(): Byte {
+        return dataStream.readByte()
+    }
+
+    @Throws(IOException::class)
+    override fun readUnsignedByte(): Int {
+        return dataStream.readUnsignedByte()
+    }
+
+    @Throws(IOException::class)
+    override fun readShort(): Short {
+        return java.lang.Short.reverseBytes(dataStream.readShort())
+    }
+
+    @Throws(IOException::class)
+    override fun readUnsignedShort(): Int {
+        return java.lang.Short.toUnsignedInt(java.lang.Short.reverseBytes(dataStream.readShort()))
+    }
+
+    @Throws(IOException::class)
+    override fun readChar(): Char {
+        return java.lang.Character.reverseBytes(dataStream.readChar())
+    }
+
+    @Throws(IOException::class)
+    override fun readInt(): Int {
+        return Integer.reverseBytes(dataStream.readInt())
+    }
+
+    @Throws(IOException::class)
+    override fun readLong(): Long {
+        return java.lang.Long.reverseBytes(dataStream.readLong())
+    }
+
+    @Throws(IOException::class)
+    override fun readFloat(): Float {
+        return java.lang.Float.intBitsToFloat(Integer.reverseBytes(dataStream.readInt()))
+    }
+
+    @Throws(IOException::class)
+    override fun readDouble(): Double {
+        return java.lang.Double.longBitsToDouble(java.lang.Long.reverseBytes(dataStream.readLong()))
+    }
+
+    @Deprecated("")
+    @Throws(IOException::class)
+    override fun readLine(): String {
+        return dataStream.readLine()
+    }
+
+    @Throws(IOException::class)
+    override fun readUTF(): String {
+        val bytes = ByteArray(readUnsignedShort())
+        readFully(bytes)
+        return String(bytes, StandardCharsets.UTF_8)
+    }
+}

--- a/src/main/kotlin/nbt/util/LittleEndianDataOutputStream.kt
+++ b/src/main/kotlin/nbt/util/LittleEndianDataOutputStream.kt
@@ -1,0 +1,77 @@
+package com.demonwav.mcdev.nbt.util
+
+import java.io.*
+import java.nio.charset.StandardCharsets
+
+open class LittleEndianDataOutputStream(stream: OutputStream) : FilterOutputStream(DataOutputStream(stream)),
+    DataOutput {
+
+    protected val dataStream = DataOutputStream(stream)
+
+    @Throws(IOException::class)
+    override fun write(bytes: ByteArray) {
+        dataStream.write(bytes)
+    }
+
+    @Throws(IOException::class)
+    override fun write(bytes: ByteArray, offset: Int, length: Int) {
+        dataStream.write(bytes, offset, length)
+    }
+
+    @Throws(IOException::class)
+    override fun writeBoolean(value: Boolean) {
+        dataStream.writeBoolean(value)
+    }
+
+    @Throws(IOException::class)
+    override fun writeByte(value: Int) {
+        dataStream.writeByte(value)
+    }
+
+    @Throws(IOException::class)
+    override fun writeShort(value: Int) {
+        dataStream.writeShort(java.lang.Short.reverseBytes(value.toShort()).toInt())
+    }
+
+    @Throws(IOException::class)
+    override fun writeChar(value: Int) {
+        dataStream.writeChar(Character.reverseBytes(value.toChar()).code)
+    }
+
+    @Throws(IOException::class)
+    override fun writeInt(value: Int) {
+        dataStream.writeInt(Integer.reverseBytes(value))
+    }
+
+    @Throws(IOException::class)
+    override fun writeLong(value: Long) {
+        dataStream.writeLong(java.lang.Long.reverseBytes(value))
+    }
+
+    @Throws(IOException::class)
+    override fun writeFloat(value: Float) {
+        dataStream.writeInt(Integer.reverseBytes(java.lang.Float.floatToIntBits(value)))
+    }
+
+    @Throws(IOException::class)
+    override fun writeDouble(value: Double) {
+        dataStream.writeLong(java.lang.Long.reverseBytes(java.lang.Double.doubleToLongBits(value)))
+    }
+
+    @Throws(IOException::class)
+    override fun writeBytes(string: String) {
+        dataStream.writeBytes(string)
+    }
+
+    @Throws(IOException::class)
+    override fun writeChars(string: String) {
+        dataStream.writeChars(string)
+    }
+
+    @Throws(IOException::class)
+    override fun writeUTF(string: String) {
+        val bytes = string.toByteArray(StandardCharsets.UTF_8)
+        writeShort(bytes.size)
+        write(bytes)
+    }
+}

--- a/src/main/kotlin/nbt/util/NetworkDataInputStream.kt
+++ b/src/main/kotlin/nbt/util/NetworkDataInputStream.kt
@@ -1,0 +1,30 @@
+package com.demonwav.mcdev.nbt.util
+
+import java.io.DataInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.nio.charset.StandardCharsets
+
+open class NetworkDataInputStream : LittleEndianDataInputStream {
+
+    constructor(stream: InputStream) : super(stream)
+    constructor(stream: DataInputStream) : super(stream)
+
+    @Throws(IOException::class)
+    override fun readInt(): Int {
+        return VarInts.readInt(dataStream)
+    }
+
+    @Throws(IOException::class)
+    override fun readLong(): Long {
+        return VarInts.readLong(dataStream)
+    }
+
+    @Throws(IOException::class)
+    override fun readUTF(): String {
+        val length = VarInts.readUnsignedInt(dataStream)
+        val bytes = ByteArray(length)
+        readFully(bytes)
+        return String(bytes, StandardCharsets.UTF_8)
+    }
+}

--- a/src/main/kotlin/nbt/util/NetworkDataOutputStream.kt
+++ b/src/main/kotlin/nbt/util/NetworkDataOutputStream.kt
@@ -1,0 +1,29 @@
+package com.demonwav.mcdev.nbt.util
+
+import java.io.DataOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+
+open class NetworkDataOutputStream : LittleEndianDataOutputStream {
+
+    constructor(stream: OutputStream) : super(stream)
+    constructor(stream: DataOutputStream) : super(stream)
+
+    @Throws(IOException::class)
+    override fun writeInt(value: Int) {
+        VarInts.writeInt(dataStream, value)
+    }
+
+    @Throws(IOException::class)
+    override fun writeLong(value: Long) {
+        VarInts.writeLong(dataStream, value)
+    }
+
+    @Throws(IOException::class)
+    override fun writeUTF(string: String) {
+        val bytes = string.toByteArray(StandardCharsets.UTF_8)
+        VarInts.writeUnsignedInt(dataStream, bytes.size.toLong())
+        write(bytes)
+    }
+}

--- a/src/main/kotlin/nbt/util/VarInts.kt
+++ b/src/main/kotlin/nbt/util/VarInts.kt
@@ -1,0 +1,77 @@
+package com.demonwav.mcdev.nbt.util
+
+import java.io.DataInput
+import java.io.DataOutput
+import java.io.IOException
+
+object VarInts {
+
+    @Throws(IOException::class)
+    fun writeInt(buffer: DataOutput, integer: Int) {
+        encodeUnsigned(buffer, ((integer shl 1) xor (integer shr 31)).toLong())
+    }
+
+    @Throws(IOException::class)
+    fun readInt(buffer: DataInput): Int {
+        val n = decodeUnsigned(buffer).toInt()
+        return (n ushr 1) xor -(n and 1)
+    }
+
+    @Throws(IOException::class)
+    fun writeUnsignedInt(buffer: DataOutput, integer: Long) {
+        encodeUnsigned(buffer, integer)
+    }
+
+    @Throws(IOException::class)
+    fun readUnsignedInt(buffer: DataInput): Int {
+        return decodeUnsigned(buffer).toInt()
+    }
+
+    @Throws(IOException::class)
+    fun writeLong(buffer: DataOutput, longInteger: Long) {
+        encodeUnsigned(buffer, (longInteger shl 1) xor (longInteger shr 63))
+    }
+
+    @Throws(IOException::class)
+    fun readLong(buffer: DataInput): Long {
+        val n = decodeUnsigned(buffer)
+        return (n ushr 1) xor -(n and 1)
+    }
+
+    @Throws(IOException::class)
+    fun writeUnsignedLong(buffer: DataOutput, longInteger: Long) {
+        encodeUnsigned(buffer, longInteger)
+    }
+
+    @Throws(IOException::class)
+    fun readUnsignedLong(buffer: DataInput): Long {
+        return decodeUnsigned(buffer)
+    }
+
+    @Throws(IOException::class)
+    private fun decodeUnsigned(buffer: DataInput): Long {
+        var result: Long = 0
+        for (shift in 0 until 64 step 7) {
+            val b = buffer.readByte().toInt()
+            result = result or ((b and 0x7F).toLong() shl shift)
+            if ((b and 0x80) == 0) {
+                return result
+            }
+        }
+        throw ArithmeticException("Varint was too large")
+    }
+
+    @Throws(IOException::class)
+    private fun encodeUnsigned(buffer: DataOutput, value: Long) {
+        var v = value
+        while (true) {
+            if (v and 0x7FL.inv() == 0L) {
+                buffer.writeByte(v.toInt())
+                return
+            } else {
+                buffer.writeByte(((v.toInt() and 0x7F) or 0x80))
+                v = v ushr 7
+            }
+        }
+    }
+}

--- a/src/main/resources/messages/MinecraftDevelopment.properties
+++ b/src/main/resources/messages/MinecraftDevelopment.properties
@@ -191,10 +191,12 @@ inspection.entity_data_param.description=Reports when the class passed to an ent
 inspection.entity_data_param.message=Entity class does not match this entity class
 inspection.entity_data_param.fix=Replace other entity class with this entity class
 
-nbt.compression.gzip=GZipped
-nbt.compression.uncompressed=Uncompressed
-nbt.compression.file_type.label=Compression:
 nbt.compression.save.button=Save
+nbt.format.little=LittleEndian
+nbt.format.big=BigEndian
+nbt.format.little_network=LittleEndian Network
+nbt.format.big_gzip=GZipped
+nbt.format.label=NBT Format:
 
 nbt.file_type.name=NBT
 nbt.file_type.description=NBT

--- a/src/main/resources/messages/MinecraftDevelopment_zh.properties
+++ b/src/main/resources/messages/MinecraftDevelopment_zh.properties
@@ -121,10 +121,12 @@ inspection.entity_data_param.description=当传递给实体数据参数定义的
 inspection.entity_data_param.message=实体类与此实体类不匹配
 inspection.entity_data_param.fix=用该实体类替换其他实体类
 
-nbt.compression.gzip=GZipped
-nbt.compression.uncompressed=未压缩
-nbt.compression.file_type.label=压缩：
 nbt.compression.save.button=保存
+nbt.format.little=小端序
+nbt.format.big=大端序
+nbt.format.little_network=小端序网络
+nbt.format.big_gzip=Gzip压缩
+nbt.format.label=NBT格式：
 
 nbt.file_type.name=NBT
 nbt.file_type.description=NBT


### PR DESCRIPTION
This PR adds support for `Little Endian` and `Network Varint` formatted NBT in Bedrock Edition. It also includes support for Bedrock Edition world `.dat` files. I'm not very familiar with `Kotlin`, so any suggestions for improvements are welcome.