### PR TITLE
Support split strings within inspections & method target references

### DIFF
--- a/src/main/kotlin/platform/mixin/inspection/reference/AmbiguousReferenceInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/reference/AmbiguousReferenceInspection.kt
@@ -35,7 +35,6 @@ import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiBinaryExpression
-import com.intellij.psi.PsiLiteral
 
 class AmbiguousReferenceInspection : MixinAnnotationAttributeInspection("method") {
 
@@ -53,8 +52,8 @@ class AmbiguousReferenceInspection : MixinAnnotationAttributeInspection("method"
         }
 
         when (value) {
-            is PsiLiteral -> checkMember(value, holder)
             is PsiArrayInitializerMemberValue -> value.initializers.forEach { checkMember(it, holder) }
+            else -> checkMember(value, holder)
         }
     }
 
@@ -80,7 +79,7 @@ class AmbiguousReferenceInspection : MixinAnnotationAttributeInspection("method"
 
             val elementFactory = JavaPsiFacade.getElementFactory(project)
 
-            if (constantValue != null && element is PsiLiteral) {
+            if (constantValue != null) {
                 val newLiteral = "\"${StringUtil.escapeStringCharacters("$constantValue*")}\""
                 element.replace(elementFactory.createExpressionFromText(newLiteral, null))
             } else {

--- a/src/main/kotlin/platform/mixin/inspection/reference/InvalidMemberReferenceInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/reference/InvalidMemberReferenceInspection.kt
@@ -33,7 +33,6 @@ import com.intellij.psi.JavaElementVisitor
 import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.PsiLiteral
 import com.intellij.psi.PsiNameValuePair
 
 class InvalidMemberReferenceInspection : MixinInspection() {
@@ -68,10 +67,10 @@ class InvalidMemberReferenceInspection : MixinInspection() {
 
             // Attempt to parse the reference
             when (value) {
-                is PsiLiteral -> checkMemberReference(value, value.constantStringValue)
                 is PsiArrayInitializerMemberValue -> value.initializers.forEach {
                     checkMemberReference(it, it.constantStringValue)
                 }
+                else -> checkMemberReference(value, value.constantStringValue)
             }
         }
 

--- a/src/main/kotlin/platform/mixin/inspection/reference/UnnecessaryQualifiedMemberReferenceInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/reference/UnnecessaryQualifiedMemberReferenceInspection.kt
@@ -34,7 +34,6 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiAnnotationMemberValue
 import com.intellij.psi.PsiArrayInitializerMemberValue
-import com.intellij.psi.PsiLiteral
 
 class UnnecessaryQualifiedMemberReferenceInspection : MixinAnnotationAttributeInspection("method") {
 
@@ -51,8 +50,8 @@ class UnnecessaryQualifiedMemberReferenceInspection : MixinAnnotationAttributeIn
         }
 
         when (value) {
-            is PsiLiteral -> checkMemberReference(value, holder)
             is PsiArrayInitializerMemberValue -> value.initializers.forEach { checkMemberReference(it, holder) }
+            else -> checkMemberReference(value, holder)
         }
     }
 

--- a/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/AbstractMethodReference.kt
@@ -43,7 +43,6 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiArrayInitializerMemberValue
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiLiteral
 import com.intellij.psi.PsiSubstitutor
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.util.parentOfType
@@ -111,9 +110,8 @@ abstract class AbstractMethodReference : PolyReferenceResolver(), MixinReference
     private fun resolve(context: PsiElement): Sequence<ClassAndMethodNode>? {
         val targets = getTargets(context) ?: return null
         val targetedMethods = when (context) {
-            is PsiLiteral -> context.constantStringValue?.let { listOf(it) } ?: emptyList()
             is PsiArrayInitializerMemberValue -> context.initializers.mapNotNull { it.constantStringValue }
-            else -> emptyList()
+            else -> context.constantStringValue?.let { listOf(it) } ?: emptyList()
         }
 
         return targetedMethods.asSequence().flatMap { method ->
@@ -141,9 +139,8 @@ abstract class AbstractMethodReference : PolyReferenceResolver(), MixinReference
         val targets = getTargets(context) ?: return null
 
         val targetedMethods = when (context) {
-            is PsiLiteral -> context.constantStringValue?.let { listOf(it) } ?: emptyList()
             is PsiArrayInitializerMemberValue -> context.initializers.mapNotNull { it.constantStringValue }
-            else -> emptyList()
+            else -> context.constantStringValue?.let { listOf(it) } ?: emptyList()
         }
 
         return targetedMethods.asSequence().flatMap { method ->


### PR DESCRIPTION
### Description:
Currently some inspections don't support strings that have been split to support a line width limit, same goes for Injection method targets.

### Changes:
Removed multiple direct `PsiLiteral` checks which where not needed, since all calls would lead to `PsiElement.constantStringValue`, which will return `null` if its not suppose to. 

Now, all these calls will use the `ConstantExpressionVisitor.compute` call which takes care of the split string logic.

### Examples:
#### Method Reference
Before - Single _(Expected behaviour)_
![Before - Single](https://github.com/user-attachments/assets/6bc9ae8a-4d13-4e03-b68d-e61730723f19)
Before - Split
![Before - Split](https://github.com/user-attachments/assets/ffee992d-e76f-4051-ae67-c976428bf29d)

After - Split
![After - Split](https://github.com/user-attachments/assets/977ba600-5fbb-42b3-8c56-80d69a619f43)

#### AmbiguousReferenceInspection
Before
![Before](https://github.com/user-attachments/assets/b9752a18-eca6-42f2-895c-9ef916ebb16f)

After
![After](https://github.com/user-attachments/assets/35388b3e-6513-49da-bf85-e112bd976d22)

#### InvalidMemberReferenceInspection
Before
![Before](https://github.com/user-attachments/assets/b3d3271a-2ac2-4f63-a181-eed3afcf0484)

After
![After](https://github.com/user-attachments/assets/95a3ee43-e485-4af7-ab25-41080e3830fa)

#### UnnecessaryQualifiedMemberReferenceInspection
Before
![Before](https://github.com/user-attachments/assets/da12c48d-92b1-4329-be09-4621fc1b7757)

After
![After](https://github.com/user-attachments/assets/40de787c-9eda-42a9-b9e7-15e4aed1a2fc)


