### PR TITLE
Add json5 support to mixin config jsons

### DIFF
--- a/src/main/kotlin/platform/mixin/config/MixinConfigFileType.kt
+++ b/src/main/kotlin/platform/mixin/config/MixinConfigFileType.kt
@@ -22,22 +22,35 @@ package com.demonwav.mcdev.platform.mixin.config
 
 import com.demonwav.mcdev.asset.PlatformAssets
 import com.intellij.json.JsonLanguage
+import com.intellij.json.json5.Json5Language
 import com.intellij.openapi.fileTypes.LanguageFileType
 import com.intellij.openapi.fileTypes.ex.FileTypeIdentifiableByVirtualFile
 import com.intellij.openapi.vfs.VirtualFile
 
-object MixinConfigFileType : LanguageFileType(JsonLanguage.INSTANCE), FileTypeIdentifiableByVirtualFile {
-
-    private val filenameRegex = "(^|\\.)mixins?(\\.[^.]+)*\\.json\$".toRegex()
+interface MixinConfigFileType : FileTypeIdentifiableByVirtualFile {
+    fun getFilenameRegex() : Regex
 
     // Dynamic file type detection is sadly needed as we're overriding the built-in json file type.
     // Simply using an extension pattern is not sufficient as there is no way to bump the version to tell
     // the cache that the pattern has changed, as it now has, without changing the file type name.
     // See https://www.plugin-dev.com/intellij/custom-language/file-type-detection/#guidelines
-    override fun isMyFileType(file: VirtualFile) = file.name.contains(filenameRegex)
+    override fun isMyFileType(file: VirtualFile) = file.name.contains(getFilenameRegex())
 
-    override fun getName() = "Mixin Configuration"
     override fun getDescription() = "Mixin configuration"
     override fun getDefaultExtension() = ""
     override fun getIcon() = PlatformAssets.MIXIN_ICON
+
+    object Json : LanguageFileType(JsonLanguage.INSTANCE), MixinConfigFileType {
+        private val filenameRegex = "(^|\\.)mixins?(\\.[^.]+)*\\.json\$".toRegex()
+
+        override fun getFilenameRegex() : Regex = filenameRegex
+        override fun getName() = "Mixin Json Configuration"
+    }
+
+    object Json5 : LanguageFileType(Json5Language.INSTANCE), MixinConfigFileType {
+        private var filenameRegex = "(^|\\.)mixins?(\\.[^.]+)*\\.json5\$".toRegex()
+
+        override fun getFilenameRegex() : Regex = filenameRegex
+        override fun getName() = "Mixin Json5 Configuration"
+    }
 }

--- a/src/main/kotlin/platform/mixin/config/MixinConfigImportOptimizer.kt
+++ b/src/main/kotlin/platform/mixin/config/MixinConfigImportOptimizer.kt
@@ -81,7 +81,7 @@ class MixinConfigImportOptimizer : ImportOptimizer {
         }
     }
 
-    override fun supports(file: PsiFile) = file is JsonFile && file.fileType == MixinConfigFileType
+    override fun supports(file: PsiFile) = file is JsonFile && file.fileType is MixinConfigFileType
 
     override fun processFile(file: PsiFile): Runnable {
         if (file !is JsonFile) {

--- a/src/main/kotlin/platform/mixin/config/inspection/MixinConfigInspection.kt
+++ b/src/main/kotlin/platform/mixin/config/inspection/MixinConfigInspection.kt
@@ -34,7 +34,7 @@ abstract class MixinConfigInspection : LocalInspectionTool() {
     protected abstract fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor
 
     private fun checkFile(file: PsiFile): Boolean {
-        return file.fileType === MixinConfigFileType && MixinModuleType.isInModule(file)
+        return file.fileType is MixinConfigFileType && MixinModuleType.isInModule(file)
     }
 
     final override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {

--- a/src/main/kotlin/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
+++ b/src/main/kotlin/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
@@ -33,7 +33,6 @@ import com.intellij.psi.PsiReferenceRegistrar
 
 class MixinConfigReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        println(this::class.qualifiedName)
         val jsonPattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
             .inFile(PlatformPatterns.psiFile().withFileType(StandardPatterns.`object`(MixinConfigFileType.Json)))
         val json5Pattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)

--- a/src/main/kotlin/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
+++ b/src/main/kotlin/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
@@ -26,23 +26,20 @@ import com.demonwav.mcdev.util.isPropertyValue
 import com.intellij.json.psi.JsonArray
 import com.intellij.json.psi.JsonStringLiteral
 import com.intellij.patterns.PlatformPatterns
-import com.intellij.patterns.PsiElementPattern
 import com.intellij.patterns.StandardPatterns
 import com.intellij.psi.PsiReferenceContributor
 import com.intellij.psi.PsiReferenceRegistrar
 
 class MixinConfigReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        val jsonPattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
-            .inFile(PlatformPatterns.psiFile().withFileType(StandardPatterns.`object`(MixinConfigFileType.Json)))
-        val json5Pattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
-            .inFile(PlatformPatterns.psiFile().withFileType(StandardPatterns.`object`(MixinConfigFileType.Json5)))
+        val anyMixinConfigFileType = StandardPatterns.or(
+            StandardPatterns.`object`(MixinConfigFileType.Json),
+            StandardPatterns.`object`(MixinConfigFileType.Json5)
+        )
 
-        registerWithPattern(registrar, jsonPattern)
-        registerWithPattern(registrar, json5Pattern)
-    }
+        val pattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
+            .inFile(PlatformPatterns.psiFile().withFileType(anyMixinConfigFileType))
 
-    private fun registerWithPattern(registrar: PsiReferenceRegistrar, pattern: PsiElementPattern.Capture<JsonStringLiteral>) {
         registrar.registerReferenceProvider(pattern.isPropertyKey(), ConfigProperty)
         registrar.registerReferenceProvider(pattern.isPropertyValue("package"), MixinPackage)
         registrar.registerReferenceProvider(pattern.isPropertyValue("plugin"), MixinPlugin)

--- a/src/main/kotlin/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
+++ b/src/main/kotlin/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
@@ -26,16 +26,24 @@ import com.demonwav.mcdev.util.isPropertyValue
 import com.intellij.json.psi.JsonArray
 import com.intellij.json.psi.JsonStringLiteral
 import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiElementPattern
 import com.intellij.patterns.StandardPatterns
 import com.intellij.psi.PsiReferenceContributor
 import com.intellij.psi.PsiReferenceRegistrar
 
 class MixinConfigReferenceContributor : PsiReferenceContributor() {
-
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        val pattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
-            .inFile(PlatformPatterns.psiFile().withFileType(StandardPatterns.`object`(MixinConfigFileType)))
+        println(this::class.qualifiedName)
+        val jsonPattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
+            .inFile(PlatformPatterns.psiFile().withFileType(StandardPatterns.`object`(MixinConfigFileType.Json)))
+        val json5Pattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
+            .inFile(PlatformPatterns.psiFile().withFileType(StandardPatterns.`object`(MixinConfigFileType.Json5)))
 
+        registerWithPattern(registrar, jsonPattern)
+        registerWithPattern(registrar, json5Pattern)
+    }
+
+    private fun registerWithPattern(registrar: PsiReferenceRegistrar, pattern: PsiElementPattern.Capture<JsonStringLiteral>) {
         registrar.registerReferenceProvider(pattern.isPropertyKey(), ConfigProperty)
         registrar.registerReferenceProvider(pattern.isPropertyValue("package"), MixinPackage)
         registrar.registerReferenceProvider(pattern.isPropertyValue("plugin"), MixinPlugin)
@@ -47,3 +55,4 @@ class MixinConfigReferenceContributor : PsiReferenceContributor() {
         registrar.registerReferenceProvider(pattern.withParent(mixinList.isPropertyValue("client")), MixinClass)
     }
 }
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -720,12 +720,20 @@
                           id="Find Mixins"/>
 
         <!-- Mixin configuration -->
-        <fileType name="Mixin Configuration" language="JSON"
-                  implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType"
+        <fileType name="Mixin Json Configuration" language="JSON"
+                  implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType$Json"
                   fieldName="INSTANCE"/>
         <psi.referenceContributor language="JSON"
                                   implementation="com.demonwav.mcdev.platform.mixin.config.reference.MixinConfigReferenceContributor"/>
         <lang.importOptimizer language="JSON"
+                              implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigImportOptimizer"/>
+
+        <fileType name="Mixin Json5 Configuration" language="JSON5"
+                  implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType$Json5"
+                  fieldName="INSTANCE"/>
+        <psi.referenceContributor language="JSON5"
+                                  implementation="com.demonwav.mcdev.platform.mixin.config.reference.MixinConfigReferenceContributor"/>
+        <lang.importOptimizer language="JSON5"
                               implementationClass="com.demonwav.mcdev.platform.mixin.config.MixinConfigImportOptimizer"/>
 
         <!-- Mixin Line Marker Providers -->


### PR DESCRIPTION
Allow mixin config json inspections and references to recognise mixin configs of the json5 file type

## Motivation

[Stonecutter](https://github.com/kikugie/stonecutter), a gradle pre-processor plugin has been gaining traction for it's use in multi-loader, multi-version projects, and a plugin that was developed alongside it, [j52j](https://github.com/kikugie/j52j), which converts json5 files to json during compilation allowing versioned comments within json files resulting in json5 being used as the file type for a mixin config:

<https://github.com/Bawnorton/BetterTrims/blob/8558c398e0cd5a85fdd5dce6b2ed9e410d239743/src/main/resources/bettertrims.mixins.json5#L6-L12>

mcdev doesn't recognise json5 as a valid file type for mixin config jsons, so this pr adds that support.