### PR TITLE
Fix "Unused Mixin Inspection" no longer providing a quick-fix

### DIFF
--- a/src/main/kotlin/platform/mixin/MixinModule.kt
+++ b/src/main/kotlin/platform/mixin/MixinModule.kt
@@ -37,8 +37,6 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
-import de.marhali.json5.Json5
-import de.marhali.json5.Json5Options
 import javax.swing.Icon
 
 class MixinModule(facet: MinecraftFacet) : AbstractModule(facet) {

--- a/src/main/kotlin/platform/mixin/config/MixinConfig.kt
+++ b/src/main/kotlin/platform/mixin/config/MixinConfig.kt
@@ -147,6 +147,8 @@ class MixinConfig(private val project: Project, private var json: JsonObject) {
     }
 
     private fun reformat() {
+        if(json.containingFile.name.endsWith(".json5")) return
+
         json = CodeStyleManager.getInstance(project).reformat(json) as JsonObject
         file?.let { file ->
             val psiFile = PsiManager.getInstance(project).findFile(file) as? JsonFile ?: return


### PR DESCRIPTION
Missed in #2375; quick fixes for adding the mixin class to a mixin config file no longer worked due to the file type being renamed. 
Also disabled the automatic reformatting on `json5` file types to avoid nuking comments as the json parser strips them otherwise.