### PR TITLE
Added local idea cersion for straighter updates on new EAP versions

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -34,6 +34,8 @@
     <name>Minecraft Development</name>
     <vendor email="kyle@denwav.dev" url="https://mcdev.io/">minecraft-dev</vendor>
 
+    <idea-version since-build="211.*" until-build="243.*" />
+
     <description><![CDATA[
         Provides first-class support for every major Java Minecraft modding or plugin development platform, including:
         <ul>


### PR DESCRIPTION
Whenever JetBrains creates an EAP version adding the plugin to the IDE results in an error because of the lack of versionsupport.
With the new idea version tag in the plugin#xml file its possible to easy update the existing plugin without any guarantee of version support just with the possibility to get it up running on the machines.