### PR TITLE
Move non-private static error to the access modifier (when there is one)

### DIFF
--- a/src/main/kotlin/platform/mixin/inspection/StaticMemberInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/StaticMemberInspection.kt
@@ -25,6 +25,7 @@ import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.INVOKER
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.OVERWRITE
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.SHADOW
 import com.demonwav.mcdev.platform.mixin.util.isMixin
+import com.demonwav.mcdev.util.findKeyword
 import com.intellij.codeInsight.intention.QuickFixFactory
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.JavaElementVisitor
@@ -33,6 +34,7 @@ import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
+import org.jetbrains.kotlin.j2k.accessModifier
 
 class StaticMemberInspection : MixinInspection() {
 
@@ -55,7 +57,7 @@ class StaticMemberInspection : MixinInspection() {
         private fun visitMember(member: PsiMember) {
             if (isProblematic(member)) {
                 holder.registerProblem(
-                    member,
+                    member.modifierList?.findKeyword(member.accessModifier()) ?: member,
                     "Non-private static members are not allowed in Mixin classes",
                     QuickFixFactory.getInstance().createModifierListFix(member, PsiModifier.PRIVATE, true, false),
                 )

--- a/src/main/kotlin/platform/mixin/inspection/StaticMemberInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/StaticMemberInspection.kt
@@ -34,7 +34,6 @@ import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
-import org.jetbrains.kotlin.j2k.accessModifier
 
 class StaticMemberInspection : MixinInspection() {
 
@@ -56,8 +55,14 @@ class StaticMemberInspection : MixinInspection() {
 
         private fun visitMember(member: PsiMember) {
             if (isProblematic(member)) {
+                val accessModifier = when {
+                    member.hasModifierProperty(PsiModifier.PUBLIC) -> PsiModifier.PUBLIC
+                    member.hasModifierProperty(PsiModifier.PROTECTED) -> PsiModifier.PROTECTED
+                    member.hasModifierProperty(PsiModifier.PRIVATE) -> PsiModifier.PRIVATE
+                    else -> PsiModifier.PACKAGE_LOCAL
+                }
                 holder.registerProblem(
-                    member.modifierList?.findKeyword(member.accessModifier()) ?: member,
+                    member.modifierList?.findKeyword(accessModifier) ?: member,
                     "Non-private static members are not allowed in Mixin classes",
                     QuickFixFactory.getInstance().createModifierListFix(member, PsiModifier.PRIVATE, true, false),
                 )


### PR DESCRIPTION
before: entire line highlighted in red:
![image](https://github.com/user-attachments/assets/6ab7ef3e-1089-441c-b3ed-35307e3a28c3)
after: only the keyword (when there is one) is highlighted:
![image](https://github.com/user-attachments/assets/79db5994-ed51-4a75-b20b-e6f444340514)
