### PR TITLE
Fix AsmDfaUtil analysis crash

### DIFF
--- a/src/main/kotlin/platform/mixin/util/AsmDfaUtil.kt
+++ b/src/main/kotlin/platform/mixin/util/AsmDfaUtil.kt
@@ -146,6 +146,9 @@ object AsmDfaUtil {
             if (type == currentClass) {
                 return currentSuperClass
             }
+            if (type.sort == Type.ARRAY) {
+                return Type.getType(Any::class.java)
+            }
             val elementFactory = JavaPsiFacade.getElementFactory(project)
             val psiType = type.toPsiType(elementFactory) as? PsiClassType ?: return null
             val clazz = psiType.resolve() ?: return null


### PR DESCRIPTION
This fixes mixinextras expression analysis not working in some cases.

It would previously return `null` when asked for the supertype of an array type, causing a crash later on when `isAssignableFrom` received a null type. Instead, we match the reflection API used by ASM by default and return `Object` as the direct superclass of any array type.