### PR TITLE
More Mixin Fixes

### DIFF
--- a/src/main/kotlin/platform/mixin/completion/InjectionPointTypedHandlerDelegate.kt
+++ b/src/main/kotlin/platform/mixin/completion/InjectionPointTypedHandlerDelegate.kt
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.platform.mixin.completion
+
+import com.demonwav.mcdev.platform.mixin.reference.InjectionPointReference
+import com.demonwav.mcdev.util.reference.findContextElement
+import com.intellij.codeInsight.AutoPopupController
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+class InjectionPointTypedHandlerDelegate : TypedHandlerDelegate() {
+    override fun checkAutoPopup(charTyped: Char, project: Project, editor: Editor, file: PsiFile): Result {
+        if (charTyped != ':' || !file.language.isKindOf(JavaLanguage.INSTANCE)) {
+            return Result.CONTINUE
+        }
+        AutoPopupController.getInstance(project).autoPopupMemberLookup(editor) {
+            val offset = editor.caretModel.offset
+            val element = it.findElementAt(offset)?.findContextElement()
+            InjectionPointReference.ELEMENT_PATTERN.accepts(element)
+        }
+        return Result.CONTINUE
+    }
+}

--- a/src/main/kotlin/platform/mixin/completion/MixinCompletionContributor.kt
+++ b/src/main/kotlin/platform/mixin/completion/MixinCompletionContributor.kt
@@ -106,12 +106,14 @@ class MixinCompletionContributor : CompletionContributor() {
             }
 
             // Process methods and fields from target class
-            findShadowTargets(psiClass, start, superMixin != null)
+            val elements = findShadowTargets(psiClass, start, superMixin != null)
                 .map { it.createLookupElement(psiClass.project) }
                 .filter { prefixMatcher.prefixMatches(it) }
                 .filter(filter, position)
                 .map { PrioritizedLookupElement.withExplicitProximity(it, 1) }
-                .forEach(r::addElement)
+                .toList()
+
+            r.addAllElements(elements)
         }
     }
 }

--- a/src/main/kotlin/platform/mixin/expression/MEExpressionMatchUtil.kt
+++ b/src/main/kotlin/platform/mixin/expression/MEExpressionMatchUtil.kt
@@ -221,7 +221,7 @@ object MEExpressionMatchUtil {
 
                     val filteredLocals = localInfo.matchLocals(
                         module, targetClass, targetMethod, actualInsn,
-                        CollectVisitor.Mode.MATCH_ALL
+                        CollectVisitor.Mode.RESOLUTION
                     ) ?: return@addMember false
                     filteredLocals.any { it.index == virtualInsn.`var` }
                 }

--- a/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InjectorAnnotationHandler.kt
@@ -141,7 +141,7 @@ abstract class InjectorAnnotationHandler : MixinAnnotationHandler {
         annotation: PsiAnnotation,
         targetClass: ClassNode,
         targetMethod: MethodNode,
-        mode: CollectVisitor.Mode = CollectVisitor.Mode.MATCH_ALL,
+        mode: CollectVisitor.Mode = CollectVisitor.Mode.RESOLUTION,
     ): List<CollectVisitor.Result<*>> {
         val cache = annotation.cached(PsiModificationTracker.MODIFICATION_COUNT) {
             ConcurrentHashMap<Pair<ClassAndMethodNode, CollectVisitor.Mode>, List<CollectVisitor.Result<*>>>()

--- a/src/main/kotlin/platform/mixin/handlers/ModifyVariableHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/ModifyVariableHandler.kt
@@ -48,7 +48,7 @@ class ModifyVariableHandler : InjectorAnnotationHandler() {
         val at = annotation.findAttributeValue("at") as? PsiAnnotation
         val atCode = at?.findAttributeValue("value")?.constantStringValue
         val isLoadStore = atCode != null && InjectionPoint.byAtCode(atCode) is AbstractLoadInjectionPoint
-        val mode = if (isLoadStore) CollectVisitor.Mode.COMPLETION else CollectVisitor.Mode.MATCH_ALL
+        val mode = if (isLoadStore) CollectVisitor.Mode.COMPLETION else CollectVisitor.Mode.RESOLUTION
         val targets = resolveInstructions(annotation, targetClass, targetMethod, mode)
 
         val targetParamsGroup = ParameterGroup(

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/ConstantInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/ConstantInjectionPoint.kt
@@ -310,15 +310,15 @@ class ConstantInjectionPoint : InjectionPoint<PsiElement>() {
         private val constantInfo: ConstantInfo?,
         private val expectedType: Type? = null,
     ) : CollectVisitor<PsiElement>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            methodNode.instructions?.iterator()?.forEachRemaining { insn ->
+        override fun accept(methodNode: MethodNode) = sequence {
+            for (insn in methodNode.instructions ?: emptyList()) {
                 val constant = (
                     insn.computeConstantValue(constantInfo?.expandConditions ?: emptySet())
-                        ?: return@forEachRemaining
+                        ?: continue
                     ).let { if (it is NullSentinel) null else it }
 
                 if (constantInfo != null && constant != constantInfo.constant) {
-                    return@forEachRemaining
+                    continue
                 }
 
                 if (expectedType != null && constant != null) {
@@ -328,7 +328,7 @@ class ConstantInjectionPoint : InjectionPoint<PsiElement>() {
                             expectedType.className != CommonClassNames.JAVA_LANG_STRING
                         )
                     ) {
-                        return@forEachRemaining
+                        continue
                     }
 
                     // then check if we expect any class literal
@@ -337,14 +337,14 @@ class ConstantInjectionPoint : InjectionPoint<PsiElement>() {
                             expectedType.className != CommonClassNames.JAVA_LANG_CLASS
                         )
                     ) {
-                        return@forEachRemaining
+                        continue
                     }
 
                     // otherwise we expect a primitive literal
                     if (expectedType.sort in Type.BOOLEAN..Type.DOUBLE &&
                         constant::class.javaPrimitiveType?.let(Type::getType) != expectedType
                     ) {
-                        return@forEachRemaining
+                        continue
                     }
                 }
 

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/ConstantStringMethodInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/ConstantStringMethodInjectionPoint.kt
@@ -204,10 +204,10 @@ class ConstantStringMethodInjectionPoint : AbstractMethodInjectionPoint() {
         private val selector: MixinSelector,
         private val ldc: String?,
     ) : CollectVisitor<PsiMethod>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
             var seenStringConstant: String? = null
-            insns.iterator().forEachRemaining { insn ->
+            for (insn in insns) {
                 if (insn is MethodInsnNode) {
                     // make sure we're coming from a string constant
                     if (seenStringConstant != null) {
@@ -225,7 +225,7 @@ class ConstantStringMethodInjectionPoint : AbstractMethodInjectionPoint() {
             }
         }
 
-        private fun processMethodInsn(insn: MethodInsnNode) {
+        private suspend fun SequenceScope<Result<PsiMethod>>.processMethodInsn(insn: MethodInsnNode) {
             // must take a string and return void
             if (insn.desc != "(Ljava/lang/String;)V") return
 

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/FieldInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/FieldInjectionPoint.kt
@@ -196,23 +196,23 @@ class FieldInjectionPoint : QualifiedInjectionPoint<PsiField>() {
         private val arrayAccess: ArrayAccessType?,
         private val fuzz: Int,
     ) : CollectVisitor<PsiField>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
-            insns.iterator().forEachRemaining { insn ->
-                if (insn !is FieldInsnNode) return@forEachRemaining
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
+            for (insn in insns) {
+                if (insn !is FieldInsnNode) continue
                 if (mode != Mode.COMPLETION) {
                     if (opcode != -1 && opcode != insn.opcode) {
-                        return@forEachRemaining
+                        continue
                     }
                     if (!selector.matchField(insn.owner, insn.name, insn.desc)) {
-                        return@forEachRemaining
+                        continue
                     }
                 }
                 val actualInsn = if (arrayAccess == null) {
                     insn
                 } else {
                     findArrayInsn(insn, arrayAccess)
-                } ?: return@forEachRemaining
+                } ?: continue
                 val fieldNode = insn.fakeResolve()
                 val psiField = fieldNode.field.findOrConstructSourceField(
                     fieldNode.clazz,

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/HeadInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/HeadInjectionPoint.kt
@@ -62,9 +62,9 @@ class HeadInjectionPoint : InjectionPoint<PsiElement>() {
         protected val clazz: ClassNode,
         mode: Mode,
     ) : CollectVisitor<PsiElement>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
-            val firstInsn = Iterable { insns.iterator() }.firstOrNull { it.opcode >= 0 } ?: return
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
+            val firstInsn = insns.firstOrNull { it.opcode >= 0 } ?: return@sequence
             addResult(firstInsn, methodNode.findOrConstructSourceMethod(clazz, project))
         }
     }

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeAssignInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeAssignInjectionPoint.kt
@@ -162,14 +162,14 @@ class InvokeAssignInjectionPoint : AbstractMethodInjectionPoint() {
         private val fuzz: Int,
         private val skip: Set<Int>,
     ) : CollectVisitor<PsiMethod>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
-            insns.iterator().forEachRemaining { insn ->
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
+            for (insn in insns) {
                 if (insn !is MethodInsnNode) {
-                    return@forEachRemaining
+                    continue
                 }
 
-                val sourceMethod = nodeMatchesSelector(insn, mode, selector, project) ?: return@forEachRemaining
+                val sourceMethod = nodeMatchesSelector(insn, mode, selector, project) ?: continue
 
                 val offset = insns.indexOf(insn)
                 val maxOffset = (offset + fuzz + 1).coerceAtMost(insns.size())

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeInjectionPoint.kt
@@ -153,14 +153,14 @@ class InvokeInjectionPoint : AbstractMethodInjectionPoint() {
         private val project: Project,
         private val selector: MixinSelector,
     ) : CollectVisitor<PsiMethod>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
-            insns.iterator().forEachRemaining { insn ->
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
+            for (insn in insns) {
                 if (insn !is MethodInsnNode) {
-                    return@forEachRemaining
+                    continue
                 }
 
-                val sourceMethod = nodeMatchesSelector(insn, mode, selector, project) ?: return@forEachRemaining
+                val sourceMethod = nodeMatchesSelector(insn, mode, selector, project) ?: continue
                 addResult(
                     insn,
                     sourceMethod,

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/JumpInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/JumpInjectionPoint.kt
@@ -92,9 +92,9 @@ class JumpInjectionPoint : InjectionPoint<PsiElement>() {
         mode: Mode,
         private val opcode: Int
     ) : CollectVisitor<PsiElement>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
-            insns.iterator().forEachRemaining { insn ->
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
+            for (insn in insns) {
                 if (insn is JumpInsnNode && (opcode == -1 || insn.opcode == opcode)) {
                     addResult(insn, methodNode.findOrConstructSourceMethod(clazz, project))
                 }

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/NewInsnInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/NewInsnInjectionPoint.kt
@@ -162,14 +162,14 @@ class NewInsnInjectionPoint : InjectionPoint<PsiMember>() {
         private val project: Project,
         private val selector: MixinSelector,
     ) : CollectVisitor<PsiMember>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
-            insns.iterator().forEachRemaining { insn ->
-                if (insn !is TypeInsnNode) return@forEachRemaining
-                if (insn.opcode != Opcodes.NEW) return@forEachRemaining
-                val initCall = findInitCall(insn) ?: return@forEachRemaining
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
+            for (insn in insns) {
+                if (insn !is TypeInsnNode) continue
+                if (insn.opcode != Opcodes.NEW) continue
+                val initCall = findInitCall(insn) ?: continue
 
-                val sourceMethod = nodeMatchesSelector(initCall, mode, selector, project) ?: return@forEachRemaining
+                val sourceMethod = nodeMatchesSelector(initCall, mode, selector, project) ?: continue
                 addResult(
                     insn,
                     sourceMethod,

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/ReturnInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/ReturnInjectionPoint.kt
@@ -133,10 +133,10 @@ abstract class AbstractReturnInjectionPoint(private val tailOnly: Boolean) : Inj
         mode: Mode,
         private val tailOnly: Boolean,
     ) : CollectVisitor<PsiElement>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
             val elementFactory = JavaPsiFacade.getElementFactory(project)
-            fun insnHandler(insn: AbstractInsnNode): Boolean {
+            suspend fun SequenceScope<Result<PsiElement>>.insnHandler(insn: AbstractInsnNode): Boolean {
                 if (insn.opcode !in Opcodes.IRETURN..Opcodes.RETURN) {
                     return false
                 }
@@ -160,7 +160,9 @@ abstract class AbstractReturnInjectionPoint(private val tailOnly: Boolean) : Inj
                     insn = insn.previous
                 }
             } else {
-                insns.iterator().forEach(::insnHandler)
+                for (insn in insns) {
+                    insnHandler(insn)
+                }
             }
         }
     }

--- a/src/main/kotlin/platform/mixin/handlers/mixinextras/ExpressionInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/mixinextras/ExpressionInjectionPoint.kt
@@ -219,11 +219,11 @@ class ExpressionInjectionPoint : InjectionPoint<PsiElement>() {
         private val poolFactory: IdentifierPoolFactory,
         private val contextType: ExpressionContext.Type,
     ) : CollectVisitor<PsiElement>(mode) {
-        override fun accept(methodNode: MethodNode) {
-            val insns = methodNode.instructions ?: return
+        override fun accept(methodNode: MethodNode) = sequence {
+            val insns = methodNode.instructions ?: return@sequence
 
             val pool = poolFactory(methodNode)
-            val flows = MEExpressionMatchUtil.getFlowMap(project, targetClass, methodNode) ?: return
+            val flows = MEExpressionMatchUtil.getFlowMap(project, targetClass, methodNode) ?: return@sequence
 
             val result = IdentityHashMap<AbstractInsnNode, Pair<PsiElement, Map<String, Any?>>>()
 
@@ -247,7 +247,7 @@ class ExpressionInjectionPoint : InjectionPoint<PsiElement>() {
             }
 
             if (result.isEmpty()) {
-                return
+                return@sequence
             }
 
             for (insn in insns) {

--- a/src/main/kotlin/platform/mixin/inspection/mixinextras/UnresolvedLocalCaptureInspection.kt
+++ b/src/main/kotlin/platform/mixin/inspection/mixinextras/UnresolvedLocalCaptureInspection.kt
@@ -61,7 +61,7 @@ class UnresolvedLocalCaptureInspection : MixinInspection() {
             for (target in targets) {
                 val matchingLocals = localInfo.matchLocals(
                     module, target.method.clazz, target.method.method, target.result.insn,
-                    CollectVisitor.Mode.MATCH_ALL
+                    CollectVisitor.Mode.RESOLUTION
                 ) ?: continue
                 if (matchingLocals.size != 1) {
                     holder.registerProblem(

--- a/src/main/kotlin/platform/mixin/reference/MixinReferenceContributor.kt
+++ b/src/main/kotlin/platform/mixin/reference/MixinReferenceContributor.kt
@@ -47,8 +47,7 @@ class MixinReferenceContributor : PsiReferenceContributor() {
 
         // Injection point types
         registrar.registerReferenceProvider(
-            PsiJavaPatterns.psiLiteral(StandardPatterns.string())
-                .insideAnnotationAttribute(AT),
+            InjectionPointReference.ELEMENT_PATTERN,
             InjectionPointReference,
         )
 

--- a/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
+++ b/src/main/kotlin/platform/mixin/reference/target/TargetReference.kt
@@ -90,7 +90,7 @@ object TargetReference : PolyReferenceResolver(), MixinReference {
         return targets.all {
             val failure = AtResolver(at, it.clazz, it.method).isUnresolved()
             // leave it if there is a filter to blame, the target reference was at least resolved
-            failure != null && failure.filterToBlame == null
+            failure != null && failure.filterStats.isEmpty()
         }
     }
 

--- a/src/main/kotlin/platform/mixin/util/InjectionPointSpecifier.kt
+++ b/src/main/kotlin/platform/mixin/util/InjectionPointSpecifier.kt
@@ -1,0 +1,48 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.platform.mixin.util
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.SLICE
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.SPECIFIER
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.parentOfType
+
+enum class InjectionPointSpecifier {
+    FIRST, LAST, ONE, ALL;
+
+    companion object {
+        fun isAllowed(at: PsiAnnotation): Boolean {
+            if (isAllowedOutsideSlice(at.project)) {
+                return true
+            }
+            val isInsideSlice = at.parentOfType<PsiAnnotation>()?.hasQualifiedName(SLICE) == true
+            return isInsideSlice
+        }
+
+        private fun isAllowedOutsideSlice(project: Project): Boolean =
+            (JavaPsiFacade.getInstance(project)
+                .findClass(SPECIFIER, GlobalSearchScope.allScope(project))
+                != null)
+    }
+}

--- a/src/main/kotlin/platform/mixin/util/MixinConstants.kt
+++ b/src/main/kotlin/platform/mixin/util/MixinConstants.kt
@@ -37,7 +37,7 @@ object MixinConstants {
         const val COMPATIBILITY_LEVEL = "org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel"
         const val CONSTANT_CONDITION = "org.spongepowered.asm.mixin.injection.Constant.Condition"
         const val INJECTION_POINT = "org.spongepowered.asm.mixin.injection.InjectionPoint"
-        const val SELECTOR = "org.spongepowered.asm.mixin.injection.InjectionPoint.Selector"
+        const val SPECIFIER = "org.spongepowered.asm.mixin.injection.InjectionPoint.Specifier"
         const val TARGET_SELECTOR = "org.spongepowered.asm.mixin.injection.selectors.TargetSelector"
         const val MIXIN_AGENT = "org.spongepowered.tools.agent.MixinAgent"
         const val MIXIN_CONFIG = "org.spongepowered.asm.mixin.transformer.MixinConfig"

--- a/src/main/kotlin/util/reference/ReferenceResolver.kt
+++ b/src/main/kotlin/util/reference/ReferenceResolver.kt
@@ -105,7 +105,7 @@ abstract class PolyReferenceResolver : PsiReferenceProvider() {
     }
 }
 
-private fun PsiElement.findContextElement(): PsiElement {
+fun PsiElement.findContextElement(): PsiElement {
     var current: PsiElement
     var parent = this
 

--- a/src/main/kotlin/util/sequences.kt
+++ b/src/main/kotlin/util/sequences.kt
@@ -29,3 +29,24 @@ fun Sequence<*>.notNullToArray(): Array<Any> {
 }
 
 fun <T> Sequence<T>.filterNotNull(transform: (T) -> Any?) = this.filter { transform(it) != null }
+
+fun <T> Sequence<T>.memoized(): Sequence<T> {
+    val cache = mutableListOf<T>()
+    val iterator = this.iterator()
+
+    return sequence {
+        var index = 0
+        while (true) {
+            if (index < cache.size) {
+                yield(cache[index])
+            } else if (iterator.hasNext()) {
+                val next = iterator.next()
+                cache.add(next)
+                yield(next)
+            } else {
+                break
+            }
+            index++
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -713,6 +713,7 @@
         <weigher key="completion"
                  implementationClass="com.demonwav.mcdev.platform.mixin.completion.MixinCompletionWeigher"
                  id="mcdev.mixin" order="first"/>
+        <typedHandler implementation="com.demonwav.mcdev.platform.mixin.completion.InjectionPointTypedHandlerDelegate" />
 
         <!-- Mixin configuration -->
         <fileType name="Mixin Json Configuration" language="JSON"


### PR DESCRIPTION
Fixes mixin shadow autocomplete results often being prioritized over regular java ones
Also adds much better support for injection point specifiers.
The latter required some decently big reworks to the `CollectVisitor` system.
During that I greatly improved the (previously nonexistent due to bugs) message about which filters were responsible for the failure.
Happy to debate any of the refactors if you disagree with them.

Also as a side note, I keep my commit history clean, so it would be preferable for my PRs not to be squashed.