### PR TITLE
Fix: Detect Mixin version using MixinBootstrap rather than library versions

### DIFF
--- a/src/main/kotlin/platform/mixin/MixinModule.kt
+++ b/src/main/kotlin/platform/mixin/MixinModule.kt
@@ -21,14 +21,10 @@
 package com.demonwav.mcdev.platform.mixin
 
 import com.demonwav.mcdev.facet.MinecraftFacet
-import com.demonwav.mcdev.facet.MinecraftFacetDetector
 import com.demonwav.mcdev.platform.AbstractModule
 import com.demonwav.mcdev.platform.PlatformType
 import com.demonwav.mcdev.platform.mixin.config.MixinConfig
 import com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType
-import com.demonwav.mcdev.platform.mixin.framework.MIXIN_LIBRARY_KIND
-import com.demonwav.mcdev.util.SemanticVersion
-import com.demonwav.mcdev.util.nullable
 import com.intellij.json.psi.JsonFile
 import com.intellij.json.psi.JsonObject
 import com.intellij.openapi.project.Project
@@ -40,14 +36,6 @@ import com.intellij.psi.search.GlobalSearchScope
 import javax.swing.Icon
 
 class MixinModule(facet: MinecraftFacet) : AbstractModule(facet) {
-    val mixinVersion by nullable {
-        var version = MinecraftFacetDetector.getLibraryVersions(facet.module)[MIXIN_LIBRARY_KIND]
-            ?: return@nullable null
-        // fabric mixin uses the format "0.10.4+mixin.0.8.4", return the original string otherwise.
-        version = version.substringAfter("+mixin.")
-        SemanticVersion.parse(version)
-    }
-
     override val moduleType = MixinModuleType
     override val type = PlatformType.MIXIN
     override val icon: Icon? = null

--- a/src/main/kotlin/platform/mixin/util/LocalVariables.kt
+++ b/src/main/kotlin/platform/mixin/util/LocalVariables.kt
@@ -46,8 +46,6 @@
 
 package com.demonwav.mcdev.platform.mixin.util
 
-import com.demonwav.mcdev.facet.MinecraftFacet
-import com.demonwav.mcdev.platform.mixin.MixinModuleType
 import com.demonwav.mcdev.platform.mixin.handlers.desugar.DesugarUtil
 import com.demonwav.mcdev.util.SemanticVersion
 import com.demonwav.mcdev.util.cached
@@ -66,7 +64,6 @@ import com.intellij.psi.PsiForeachStatement
 import com.intellij.psi.PsiLambdaExpression
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
-import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiStatement
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiTypes
@@ -412,7 +409,7 @@ object LocalVariables {
 
     private val resurrectLocalsChange = SemanticVersion.release(0, 8, 3)
     private fun detectCurrentSettings(module: Module): Settings? {
-        val mixinVersion = MinecraftFacet.getInstance(module, MixinModuleType)?.mixinVersion ?: return null
+        val mixinVersion = module.mixinVersion ?: return null
         return if (mixinVersion < resurrectLocalsChange) {
             Settings.NO_RESURRECT
         } else {

--- a/src/main/kotlin/platform/mixin/util/Mixin.kt
+++ b/src/main/kotlin/platform/mixin/util/Mixin.kt
@@ -28,10 +28,12 @@ import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MIXIN
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO_RETURNABLE
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.MixinExtras.OPERATION
+import com.demonwav.mcdev.util.SemanticVersion
 import com.demonwav.mcdev.util.cached
 import com.demonwav.mcdev.util.computeStringArray
 import com.demonwav.mcdev.util.findModule
 import com.demonwav.mcdev.util.resolveClassArray
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
@@ -41,6 +43,7 @@ import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiDisjunctionType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiIntersectionType
+import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiPrimitiveType
@@ -249,3 +252,13 @@ fun isMixinEntryPoint(element: PsiElement?): Boolean {
 
 val PsiElement.isFabricMixin: Boolean get() =
     JavaPsiFacade.getInstance(project).findClass(MixinConstants.Classes.FABRIC_UTIL, resolveScope) != null
+
+val Module.mixinVersion: SemanticVersion?
+    get() {
+        val facade = JavaPsiFacade.getInstance(project)
+        val bootstrap = facade.findClass(MixinConstants.Classes.MIXIN_BOOTSTRAP, moduleWithLibrariesScope)
+            ?: return null
+        val versionField = bootstrap.findFieldByName("VERSION", false) ?: return null
+        val version = (versionField.initializer as? PsiLiteralExpression)?.value as? String ?: return null
+        return SemanticVersion.tryParse(version)
+    }

--- a/src/main/kotlin/platform/mixin/util/MixinConstants.kt
+++ b/src/main/kotlin/platform/mixin/util/MixinConstants.kt
@@ -46,6 +46,7 @@ object MixinConstants {
         const val SELECTOR_ID = "org.spongepowered.asm.mixin.injection.selectors.ITargetSelectorDynamic.SelectorId"
         const val SHIFT = "org.spongepowered.asm.mixin.injection.At.Shift"
         const val LOCAL_CAPTURE = "org.spongepowered.asm.mixin.injection.callback.LocalCapture"
+        const val MIXIN_BOOTSTRAP = "org.spongepowered.asm.launch.MixinBootstrap"
 
         const val SERIALIZED_NAME = "com.google.gson.annotations.SerializedName"
         const val MIXIN_SERIALIZED_NAME = "org.spongepowered.include.$SERIALIZED_NAME"


### PR DESCRIPTION
Relying on the name / version of the library is unnecessary and causes issues in legacy environments where mixin is supplied by many people.