### PR TITLE
fix: fix bungeecord test dependency. | fix: fix building not working.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ fuel-coroutines = { module = "com.github.kittinunf.fuel:fuel-coroutines", versio
 # Testing
 test-mixin = "org.spongepowered:mixin:0.8.5"
 test-spigotapi = "org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT"
-test-bungeecord = "net.md-5:bungeecord-api:1.21-R0.3-SNAPSHOT"
+test-bungeecord = "net.md-5:bungeecord-api:1.21-R0.3"
 test-spongeapi = "org.spongepowered:spongeapi:7.4.0"
 test-fabricloader = "net.fabricmc:fabric-loader:0.15.11"
 test-nbt = "com.demonwav.mcdev:all-types-nbt:1.0"


### PR DESCRIPTION
The sonatype repository (where bungeecord was hosted) has moved to https://central.sonatype.com/ and this repository doesn't supported snapshots (it seems at least).

Btw, you can see build workflows runs on my repository.