### PR TITLE
Avoid crash for exotic MC versions

### DIFF
--- a/src/main/kotlin/util/psi-utils.kt
+++ b/src/main/kotlin/util/psi-utils.kt
@@ -377,7 +377,7 @@ private fun Module.findMcpModule(): McpModule? {
 val PsiElement.mcVersion: SemanticVersion?
     get() = this.cached {
         findMcpModule()?.let {
-            SemanticVersion.parse(it.getSettings().minecraftVersion ?: return@let null)
+            SemanticVersion.tryParse(it.getSettings().minecraftVersion ?: return@let null)
         }
     }
 


### PR DESCRIPTION
Avoid crash message when opening files for versions like `b1.7.3`.
This PR avoids changing any parsing code.

Exception in question:
`IllegalArgumentException: Failed to parse version part as integer: b1 (whole version text: b1.7.3)`