### PR TITLE
Fix write-unsafe VFS refresh when loading templates

### DIFF
--- a/src/main/kotlin/creator/custom/providers/TemplateProvider.kt
+++ b/src/main/kotlin/creator/custom/providers/TemplateProvider.kt
@@ -155,7 +155,7 @@ interface TemplateProvider {
 
             try {
                 return file.refreshSync(modalityState)
-                    ?.inputStream?.reader()?.use { TemplateResourceBundle(it, parent) }
+                    .inputStream.reader().use { TemplateResourceBundle(it, parent) }
             } catch (t: Throwable) {
                 if (t is ControlFlowException) {
                     return parent

--- a/src/main/kotlin/util/files.kt
+++ b/src/main/kotlin/util/files.kt
@@ -22,11 +22,9 @@ package com.demonwav.mcdev.util
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.writeAction
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.newvfs.RefreshQueue
 import java.io.File
 import java.io.IOException
 import java.nio.file.Path
@@ -79,18 +77,13 @@ val VirtualFile.mcDomainAndPath: Pair<String, String>?
 operator fun Manifest.get(attribute: String): String? = mainAttributes.getValue(attribute)
 operator fun Manifest.get(attribute: Attributes.Name): String? = mainAttributes.getValue(attribute)
 
-suspend fun VirtualFile.refreshSync(modalityState: ModalityState): VirtualFile? {
-    fun refresh() {
-        RefreshQueue.getInstance().refresh(false, this.isDirectory, null, modalityState, this)
-    }
-
-    if (ApplicationManager.getApplication().isWriteAccessAllowed) {
-        refresh()
-    } else {
-        writeAction {
-            refresh()
-        }
-    }
-
-    return this.parent?.findOrCreateChildData(this, this.name)
+suspend fun VirtualFile.refreshSync(modalityState: ModalityState): VirtualFile {
+    val file = this
+    ApplicationManager.getApplication().invokeAndWait(
+        {
+            file.refresh(false, true)
+        },
+        modalityState
+    )
+    return file
 }


### PR DESCRIPTION
closes  #2592
Run VFS refresh via Application.invokeAndWait(..., modalityState) instead of calling RefreshQueue.refresh() inside a writeAction.

This preserves the current wizard/dialog modality state and prevents "Write-unsafe context! Model changes are allowed from write-safe contexts only"errors when loading templates on newer IntelliJ Platform versions.