### PR TITLE
NeoModDevGradleModelBuilderImpl: Only get version if not in vanilla mode

### DIFF
--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/neomoddev/NeoModDevGradleModelBuilderImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/neomoddev/NeoModDevGradleModelBuilderImpl.groovy
@@ -49,22 +49,27 @@ final class NeoModDevGradleModelBuilderImpl implements ModelBuilderService {
             return null
         }
 
-        def neoforgeVersionProp = extension.version
-        def neoforgeVersion
-        if (neoforgeVersionProp instanceof String) {
-            neoforgeVersion = neoforgeVersionProp
-        } else if (neoforgeVersionProp instanceof Provider) {
-            neoforgeVersion = neoforgeVersionProp.getOrNull()
-        } else {
-            return null
-        }
-
         def neoFormVersion
         try {
             neoFormVersion = extension.neoFormVersion.getOrNull()
         } catch (InvalidUserCodeException ignore) {
             // Happens when the NeoForm version is not set
             neoFormVersion = null
+        }
+        
+        def neoforgeVersion
+        if (neoFormVersion != null) {
+            neoforgeVersion = null
+        } else {
+            def neoforgeVersionProp = extension.version
+        
+            if (neoforgeVersionProp instanceof String) {
+                neoforgeVersion = neoforgeVersionProp
+            } else if (neoforgeVersionProp instanceof Provider) {
+                neoforgeVersion = neoforgeVersionProp.getOrNull()
+            } else {
+                return null
+            }
         }
 
         def accessTransformersRaw = extension.accessTransformers


### PR DESCRIPTION
ModDevGradle, for whatever reason, throws if you get the version when it's in vanilla mode. Since MCDev currently fetches the version no matter what, this makes it impossible to use vanilla projects with MCDev.

This PR makes it check the NeoForm version _first_ (which is only there if it's a vanilla project), then only if it is confirmed to not be a vanilla project gets the NeoForge version.

I'm also making a PR for MDG to not throw an exception when getting the version, because that's a huge contract violation, but that is not guaranteed to go through.  In the meantime, this will let people work on vanilla projects.

Fixes #2570