### PR TITLE
Fix potential deadlock when triggering project refresh while holding write lock

### DIFF
--- a/src/main/kotlin/facet/MinecraftFacet.kt
+++ b/src/main/kotlin/facet/MinecraftFacet.kt
@@ -35,6 +35,7 @@ import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetTypeId
 import com.intellij.facet.FacetTypeRegistry
 import com.intellij.ide.projectView.ProjectView
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.module.Module
@@ -77,7 +78,15 @@ class MinecraftFacet(
         roots.clear()
     }
 
-    fun refresh() = runWriteActionAndWait {
+    fun refresh() {
+        refreshWritePhase()
+        // Refresh the project view separately to not hold the write lock
+        ApplicationManager.getApplication().invokeLater {
+            ProjectView.getInstance(module.project).refresh()
+        }
+    }
+
+    private fun refreshWritePhase() = runWriteActionAndWait {
         if (module.isDisposed) {
             return@runWriteActionAndWait
         }
@@ -118,8 +127,6 @@ class MinecraftFacet(
 
         newlyEnabled.forEach(AbstractModule::init)
         modules.forEach(AbstractModule::refresh)
-
-        ProjectView.getInstance(module.project).refresh()
     }
 
     private fun updateRoots() = runWriteAction {

--- a/src/main/kotlin/platform/mcp/McpModule.kt
+++ b/src/main/kotlin/platform/mcp/McpModule.kt
@@ -29,6 +29,7 @@ import com.demonwav.mcdev.platform.mcp.util.McpConstants
 import com.demonwav.mcdev.translations.TranslationFileListener
 import com.demonwav.mcdev.util.runWriteTaskLater
 import com.intellij.json.JsonFileType
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder
 import com.intellij.openapi.externalSystem.util.ExternalSystemUtil
 import com.intellij.openapi.fileTypes.FileTypeManager
@@ -71,7 +72,10 @@ class McpModule(facet: MinecraftFacet) : AbstractModule(facet) {
             }
 
             if (requiresRefresh) {
-                ExternalSystemUtil.refreshProjects(ImportSpecBuilder(project, GradleConstants.SYSTEM_ID))
+                // Schedule Gradle project refresh outside write lock
+                ApplicationManager.getApplication().invokeLater {
+                    ExternalSystemUtil.refreshProjects(ImportSpecBuilder(project, GradleConstants.SYSTEM_ID))
+                }
             }
         }
     }


### PR DESCRIPTION
The common problem among all the stacktraces I looked at is a deadlock occuring when a thread holding the write lock tries to access the AWT or the write intent lock. My reading of the IntelliJ [threading model](https://plugins.jetbrains.com/docs/intellij/threading-model.html) documentation suggests this can be problematic. Since both of the two cases I found appear to be simple (triggering a project refresh), it seems that the simplest fix is to just queue the refresh call to be run later on the correct thread, independently of any write lock held by the surrounding method.

It will take some time to confirm if this actually fixes the problem, because it is impossible to reproduce reliably, hence why I resorted to stacktrace analysis.

In theory, this fixes #2566, fixes #2519 (there may also be other issue numbers I'm not aware of)