### PR TITLE
New: Support `@Shadow` constructors.

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/ShadowHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/ShadowHandler.kt
@@ -48,7 +48,7 @@ class ShadowHandler : MixinMemberAnnotationHandler {
     override fun resolveTarget(annotation: PsiAnnotation, targetClass: ClassNode): List<MixinTargetMember> {
         if (hasAliases(annotation)) return emptyList()
         val member = annotation.parentOfType<PsiMember>() ?: return emptyList()
-        val name = stripPrefix(annotation, member) ?: return emptyList()
+        val name = getEffectiveName(annotation, member) ?: return emptyList()
         return when (member) {
             is PsiMethod -> listOfNotNull(
                 targetClass.findMethod(MemberReference(name, member.descriptor))
@@ -75,7 +75,7 @@ class ShadowHandler : MixinMemberAnnotationHandler {
             is PsiField -> "field"
             else -> return null
         }
-        return "Unresolved $type ${member.name} in target class"
+        return "Unresolved $type ${getEffectiveName(annotation, member)} in target class"
     }
 
     fun findFirstShadowTargetForNavigation(member: PsiMember): SmartPsiElementPointer<PsiElement>? {
@@ -94,7 +94,10 @@ class ShadowHandler : MixinMemberAnnotationHandler {
 
     private fun hasAliases(shadow: PsiAnnotation) = shadow.findDeclaredAttributeValue("aliases").isNotEmpty()
 
-    private fun stripPrefix(shadow: PsiAnnotation, member: PsiMember): String? {
+    private fun getEffectiveName(shadow: PsiAnnotation, member: PsiMember): String? {
+        if (member is PsiMethod && member.isConstructor) {
+            return "<init>"
+        }
         // Strip prefix
         val prefix = shadow.findDeclaredAttributeValue("prefix")?.constantStringValue
             ?: MixinConstants.DEFAULT_SHADOW_PREFIX

--- a/src/main/kotlin/util/bytecode-utils.kt
+++ b/src/main/kotlin/util/bytecode-utils.kt
@@ -172,9 +172,13 @@ private fun PsiMethod.appendDescriptor(builder: StringBuilder): StringBuilder {
     builder.append('(')
     if (isConstructor) {
         containingClass?.let { containingClass ->
-            if (containingClass.hasModifierProperty(PsiModifier.STATIC)) return@let
-            val outerClass = containingClass.containingClass
-            outerClass?.type()?.appendDescriptor(builder)
+            if (!containingClass.hasModifierProperty(PsiModifier.STATIC)) {
+                val outerClass = containingClass.containingClass
+                outerClass?.type()?.appendDescriptor(builder)
+            }
+            if (containingClass.isEnum) {
+                builder.append("Ljava/lang/String;I")
+            }
         }
     }
     for (parameter in parameterList.parameters) {


### PR DESCRIPTION
Will be introduced in FabricMixin along with enum extensions. We don't need to bother checking whether the feature is supported on the current Mixin, because the user will already get a compile error about Shadow not being applicable to constructors.