### PR TITLE
NeoModDevGradleModelBuilderImpl: Make neoFormVersion check class of property

### DIFF
--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/neomoddev/NeoModDevGradleModelBuilderImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/neomoddev/NeoModDevGradleModelBuilderImpl.groovy
@@ -51,7 +51,14 @@ final class NeoModDevGradleModelBuilderImpl implements ModelBuilderService {
 
         def neoFormVersion
         try {
-            neoFormVersion = extension.neoFormVersion.getOrNull()
+            def neoFormVersionProp = extension.neoFormVersion
+            if (neoFormVersionProp instanceof String) {
+                neoFormVersion = neoFormVersionProp
+            } else if (neoFormVersionProp instanceof Provider) {
+                neoFormVersion = neoFormVersionProp.getOrNull()
+            } else {
+                neoFormVersion = null
+            }
         } catch (InvalidUserCodeException ignore) {
             // Happens when the NeoForm version is not set
             neoFormVersion = null


### PR DESCRIPTION
Seems like fixing https://github.com/minecraft-dev/MinecraftDev/pull/2594 revealed another bug in the existing NeoForm version handling: the previous code called `getOrNull` on something that wasn't guaranteed to be a Provider.

The problem in question:
```
groovy.lang.MissingMethodException: No signature of method: java.lang.String.getOrNull() is applicable for argument types: () values: []
	at com.demonwav.mcdev.platform.mcp.gradle.tooling.neomoddev.NeoModDevGradleModelBuilderImpl.buildAll(NeoModDevGradleModelBuilderImpl.groovy:54)
```

Fixes this by doing the same type-checking for `neoFormVersion` that we do for `neoforgeVersionProp`.