### PR TITLE
Add missing Velocity template translation

### DIFF
--- a/src/main/resources/messages/MinecraftDevelopment.properties
+++ b/src/main/resources/messages/MinecraftDevelopment.properties
@@ -115,6 +115,7 @@ creator.ui.include_plugin_loader.label=Include plugin loader file\:
 creator.ui.java_plugin_loader.label=Generate the plugin loader in Java\:
 
 creator.ui.run_paper_plugin.label=Use run-paper Gradle plugin\:
+creator.ui.run_velocity_plugin.label=Use run-velocity Gradle plugin\:
 creator.ui.accept_eula.label=Add eula-agree runServer JVM flag\:
 creator.ui.accept_eula.warning=By using this feature, you agree to the <a href='https://www.minecraft.net/en-us/eula'>Minecraft EULA</a>.
 creator.ui.shadow_plugin.label=Use shadow Gradle plugin\:


### PR DESCRIPTION
Adds the required translations for https://github.com/minecraft-dev/templates/pull/49.