### PR TITLE
Fix valid class tweaker files initially erroring until reopened

### DIFF
--- a/src/main/grammars/CtLexer.flex
+++ b/src/main/grammars/CtLexer.flex
@@ -62,6 +62,7 @@ TYPE_VARIABLE=T[^;\n]+;
 ACCESS_ELEMENT=accessible|transitive-accessible|extendable|transitive-extendable|mutable|transitive-mutable
 INJECT_INTERFACE_ELEMENT=inject-interface|transitive-inject-interface
 EXTEND_ENUM_ELEMENT=extend-enum|transitive-extend-enum
+INCOMPLETE_ENTRY_START=[a-zA-Z-]+
 CLASS_ELEMENT=class
 METHOD_ELEMENT=method
 FIELD_ELEMENT=field
@@ -78,6 +79,9 @@ WHITE_SPACE=\s
     {ACCESS_ELEMENT}                            { yybegin(AW_ENTRY); return ACCESS_ELEMENT; }
     {INJECT_INTERFACE_ELEMENT}                  { yybegin(ITF_ENTRY_KEY); return INJECT_INTERFACE_ELEMENT; }
     {EXTEND_ENUM_ELEMENT}                       { yybegin(ENUM_NAME); return EXTEND_ENUM_ELEMENT; }
+    // Create tokens for incomplete or invalid inputs too if they look like real inputs (same characters)
+    // to prevent a bug where the entire file is erroring until reopened.
+    {INCOMPLETE_ENTRY_START}                    { return INCOMPLETE_ENTRY_START; }
 }
 
 <HEADER> {

--- a/src/main/grammars/CtParser.bnf
+++ b/src/main/grammars/CtParser.bnf
@@ -137,5 +137,5 @@ signature ::= CLASS_NAME_ELEMENT (LESS_THAN signature_element+ GREATER_THAN)?
 signature_element ::= OPEN_BRACKET* (PRIMITIVE | TYPE_VARIABLE | signature_class_element)
 signature_class_element ::= ASTERISK | ( (PLUS | MINUS)? SIGNATURE_CLASS_VALUE_START (LESS_THAN signature_element GREATER_THAN)? SIGNATURE_CLASS_VALUE_END )
 
-// Unused rule to generate the INCOMPLETE_ENTRY_START token.
+// Unused rule to generate the INCOMPLETE_ENTRY_START token type used in the lexer.
 private incomplete_entry_start_holder ::= INCOMPLETE_ENTRY_START

--- a/src/main/grammars/CtParser.bnf
+++ b/src/main/grammars/CtParser.bnf
@@ -136,3 +136,6 @@ desc_element ::= OPEN_BRACKET* (PRIMITIVE | CLASS_VALUE) {
 signature ::= CLASS_NAME_ELEMENT (LESS_THAN signature_element+ GREATER_THAN)?
 signature_element ::= OPEN_BRACKET* (PRIMITIVE | TYPE_VARIABLE | signature_class_element)
 signature_class_element ::= ASTERISK | ( (PLUS | MINUS)? SIGNATURE_CLASS_VALUE_START (LESS_THAN signature_element GREATER_THAN)? SIGNATURE_CLASS_VALUE_END )
+
+// Unused rule to generate the INCOMPLETE_ENTRY_START token.
+incomplete_entry_start_holder ::= INCOMPLETE_ENTRY_START

--- a/src/main/grammars/CtParser.bnf
+++ b/src/main/grammars/CtParser.bnf
@@ -138,4 +138,4 @@ signature_element ::= OPEN_BRACKET* (PRIMITIVE | TYPE_VARIABLE | signature_class
 signature_class_element ::= ASTERISK | ( (PLUS | MINUS)? SIGNATURE_CLASS_VALUE_START (LESS_THAN signature_element GREATER_THAN)? SIGNATURE_CLASS_VALUE_END )
 
 // Unused rule to generate the INCOMPLETE_ENTRY_START token.
-incomplete_entry_start_holder ::= INCOMPLETE_ENTRY_START
+private incomplete_entry_start_holder ::= INCOMPLETE_ENTRY_START


### PR DESCRIPTION
This slightly hacky fix utilises a "fake token" that matches real-looking line starts. It's unused in the parser so the user will still see an error when needed as the `INCOMPLETE_ENTRY_START` tokens are always illegal.

The exact issue seems to be with the `BAD_CHARACTER` returns for valid *characters*, since the characters themselves can be valid later when the keyword is fully typed.